### PR TITLE
feat: allow transcript URL

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -30,8 +30,14 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
     icon_class = 'other'
     loader = ResourceLoader(__name__)
 
-    editable_fields = ('sources', 'allow_audio_download', 'description', 'transcript_file', 'embed_url')
-
+    editable_fields = (
+        'sources',
+        'allow_audio_download',
+        'description',
+        'transcript_file',
+        'transcript_url',
+        'embed_url',
+    )
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
@@ -83,7 +89,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'allow_audio_download': self.allow_audio_download,
                 'audio_download_url': audio_download_url,
                 'description': self.description,
-                'transcript_file': self.transcript_file,
+                'transcript_file': self.transcript_url or self.transcript_file,
                 'start_time': self.start_time,
                 'end_time': self.end_time,
                 'embed_url': self.embed_url
@@ -112,6 +118,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         self.start_time = float(self.convert_time_to_seconds(data.get('start_time', '00:00')))
         self.end_time = float(self.convert_time_to_seconds(data.get('end_time', '00:00')))
         self.embed_url = data.get('embed_url', '') if not data.get('sources', '') else ''
+        self.transcript_url = data.get('transcript_url')
 
         if 'transcript_file' in request.params and hasattr(request.params['transcript_file'], 'file'):
             transcript_file = request.params['transcript_file']
@@ -123,6 +130,5 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             self.transcript_file = f'/media/transcripts/{file_name}'
         else:
             self.transcript_file = None
-
 
         return Response(json_body={'result': 'success'})

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -47,6 +47,12 @@ class AudioFields(object):
         scope=Scope.settings
     )
 
+    transcript_url = String(
+        help="Transcript file URL",
+        default=None,
+        scope=Scope.settings
+    )
+
     start_time = Float(
         help="Start time in seconds",
         default=0.0,
@@ -83,3 +89,5 @@ class AudioFields(object):
                         _scheme, _netloc, path, _params, _qs, _fragment = urlparse(source)
                         if path is None:
                             validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"Invalid URL '") + source + _(u"' entered.")))
+        if data.transcript_file and data.transcript_url:
+            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at most one transcript source!")))

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -34,6 +34,11 @@
                     <p class="help">Only WebVTT format is supported.</p>
                 </div>
                 <div class="field">
+                    <label for="transcript_url">Audio transcript URL</label>
+                    <input type="text" id="transcript_url" name="transcript_url" {% if self.transcript_url %}value="{{ self.transcript_url }}"{% endif %} />
+                    <p class="help">Only WebVTT format is supported.</p>
+                </div>
+                <div class="field">
                     <label for="allow_audio_download">Allow audio download</label>
                     <select id="allow_audio_download" name="allow_audio_download">
                         <option value="true" {% if self.allow_audio_download %}selected{% endif %}>Yes</option>


### PR DESCRIPTION
## Description

Allows providing a URL to a transcript file as an alternative to uploading one.

## Testing instructions

1. Install and configure the XBlock
2. Set some URL as transcript file URL
   ![image](https://github.com/user-attachments/assets/ebca72c0-9f48-4a1f-8fc7-cebca5fb1c9e)
3. See that it is used as transcript source
   ![image](https://github.com/user-attachments/assets/a4ae4447-360b-43e5-a566-95c7ba2772ce)

## Deadline

None

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-9552