### PR TITLE
Fix download link alignment

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -1,55 +1,119 @@
 # -*- coding: utf-8 -*-
 import logging
+import pkg_resources
+import os
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
+from webob.response import Response
 
 from xblock.core import XBlock
 from xblock.fragment import Fragment
-from xblockutils.studio_editable import StudioEditableXBlockMixin
-from xblockutils.resources import ResourceLoader
 
 from .fields import AudioFields
 from .utils import get_path_mimetype
 
+try:
+    from xblock.utils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
+except ModuleNotFoundError:  # For compatibility with Palm and earlier
+    from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
+
+try:
+    from xblock.utils.resources import ResourceLoader
+except ModuleNotFoundError:  # For compatibility with releases older than Quince.
+    from xblockutils.resources import ResourceLoader
+
+
 
 log = logging.getLogger(__name__)
-loader = ResourceLoader(__name__)
-
 
 @XBlock.needs('i18n')
-class AudioBlock(AudioFields, StudioEditableXBlockMixin, XBlock):
-    # Styling and asset controls.
-    icon_class = 'audio'
-    js_module_name = "Audio"
+class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMixin, XBlock):
+    icon_class = 'other'
+    loader = ResourceLoader(__name__)
 
-    editable_fields = ('sources', 'allow_audio_download')
+    editable_fields = ('sources', 'allow_audio_download', 'description', 'transcript_file', 'embed_url')
+
+
+    def resource_string(self, path):
+        """Handy helper for getting resources from our kit."""
+        data = pkg_resources.resource_string(__name__, path)
+        return data.decode("utf8")
+
+
+    def studio_view(self, context):
+        """
+        View for editing the XBlock settings in Studio
+        """
+        html = self.loader.render_django_template(
+            'templates/html/audio_edit.html', {
+                'self': self
+            })
+
+        fragment = Fragment(html)
+        fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/audio.css'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/audio_edit.js'))
+        fragment.initialize_js('AudioBlockStudio')
+        return fragment
 
 
     def student_view(self, context):
-      """
-      Player view, displayed to the student
-      """
+        """
+        Player view, displayed to the student
+        """
+        sources = list(filter(None, self.sources.split('\n')) if self.sources else '')
+        audio_download_url = sources[0] if sources else None
 
-      sources = filter(None, self.sources.split('\n')) if self.sources else ''
-      audio_download_url = sources[0] if sources else None
+        # Add the MIME type if we think we know it.
+        annotated_sources = []
+        for source in sources:
+            type = get_path_mimetype(source)
+            annotated_sources.append((source, type))
 
-      # Add the MIME type if we think we know it.
-      annotated_sources = []
-      for source in sources:
-          type = get_path_mimetype(source)
+        html = self.loader.render_django_template(
+            'templates/html/audio.html', {
+                'audio_id': self.audio_id,
+                'sources': annotated_sources,
+                'allow_audio_download': self.allow_audio_download,
+                'audio_download_url': audio_download_url,
+                'description': self.description,
+                'transcript_file': self.transcript_file,
+                'start_time': self.start_time,
+                'end_time': self.end_time,
+                'embed_url': self.embed_url
+            })
 
-          annotated_sources.append((source, type))
+        fragment = Fragment(html)
+        fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/audio.css'))
+        fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/mediaelement.player.min.css'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/mediaelement.player.min.js'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/audio.js'))
 
-      fragment = Fragment()
-      fragment.add_content(loader.render_mako_template(
-        'templates/html/audio.html', {
-          'audio_id': self.audio_id,
-          'sources': annotated_sources,
-          'allow_audio_download': self.allow_audio_download,
-          'audio_download_url': audio_download_url
-        }))
-      fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/audio.css'))
-      fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/mediaelement.player.min.css'))
-      fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/mediaelement.player.min.js'))
-      fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/audio.js'))
-      fragment.initialize_js("AudioBlock")
+        fragment.initialize_js("AudioBlock")
 
-      return fragment
+        return fragment
+
+
+    @XBlock.handler
+    def studio_submit(self, request, suffix=''):
+        """
+        Handle studio form submissions
+        """
+        data = request.POST
+        self.sources = data.get('sources')
+        self.allow_audio_download = data.get('allow_audio_download') == 'true'
+        self.start_time = float(data.get('start_time', 0.0))
+        self.end_time = float(data.get('end_time', 0.0))
+        self.embed_url = data.get('embed_url', '') if not data.get('sources', '') else ''
+
+        if 'transcript_file' in request.params:
+            transcript_file = request.params['transcript_file']
+            file_name = transcript_file.filename
+            file_path = os.path.join(settings.MEDIA_ROOT, 'transcripts', file_name)
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            with open(file_path, 'wb') as f:
+                f.write(transcript_file.file.read())
+            self.transcript_file = f'/media/transcripts/{file_name}'
+
+
+        return Response(json_body={'result': 'success'})

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -30,8 +30,14 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
     icon_class = 'other'
     loader = ResourceLoader(__name__)
 
-    editable_fields = ('sources', 'allow_audio_download', 'description', 'transcript_file', 'embed_url')
-
+    editable_fields = (
+        'sources',
+        'allow_audio_download',
+        'description',
+        'transcript_file',
+        'transcript_url',
+        'embed_url',
+    )
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
@@ -83,7 +89,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'allow_audio_download': self.allow_audio_download,
                 'audio_download_url': audio_download_url,
                 'description': self.description,
-                'transcript_file': self.transcript_file,
+                'transcript_file': self.transcript_url or self.transcript_file,
                 'start_time': self.start_time,
                 'end_time': self.end_time,
                 'embed_url': self.embed_url
@@ -112,6 +118,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         self.start_time = float(self.convert_time_to_seconds(data.get('start_time', '00:00')))
         self.end_time = float(self.convert_time_to_seconds(data.get('end_time', '00:00')))
         self.embed_url = data.get('embed_url', '') if not data.get('sources', '') else ''
+        self.transcript_url = data.get('transcript_url')
 
         if 'transcript_file' in request.params and hasattr(request.params['transcript_file'], 'file'):
             transcript_file = request.params['transcript_file']
@@ -123,6 +130,5 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             self.transcript_file = f'/media/transcripts/{file_name}'
         else:
             self.transcript_file = None
-
 
         return Response(json_body={'result': 'success'})

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -1,7 +1,7 @@
-from xblock.fields import Scope, String, List, Boolean, UNIQUE_ID
+from xblock.fields import Scope, String, Boolean, UNIQUE_ID, Float
 from xblock.validation import ValidationMessage
 
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 # Override '_' so they can be scraped for translations.
 _ = lambda text: text
@@ -34,20 +34,52 @@ class AudioFields(object):
         default=True,
     )
 
+    description = String(
+        display_name="Description",
+        default="",
+        scope=Scope.settings,
+        help="Description text to be shown before the player."
+    )
+
+    transcript_file = String(
+        help="Transcript file path",
+        default=None,
+        scope=Scope.settings
+    )
+
+    start_time = Float(
+        help="Start time in seconds",
+        default=0.0,
+        scope=Scope.settings
+    )
+
+    end_time = Float(
+        help="End time in seconds",
+        default=0.0,
+        scope=Scope.content
+    )
+
+    embed_url = String(
+        help="URL to embed third-party podcast",
+        scope=Scope.content,
+        default=""
+    )
+
     def validate_field_data(self, validation, data):
         """
         Ensure we've been passed legitimate values, particularly for the audio URLs.
         """
-        if data.sources is None:
-            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at least one source URL!")))
+        if not (data.sources or data.embed_url) :
+            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at least one audio source!")))
         else:
-            sources = filter(None, data.sources.split('\n'))
-            if len(sources) == 0:
-                validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at least one source URL!")))
-            else:
-                for source in sources:
-                    # Parse the string to see if it's a URL.  It has to, at least, have a path, which could
-                    # mean it's a relative `/static/` URL.
-                    _scheme, _netloc, path, _params, _qs, _fragment = urlparse(source)
-                    if path is None:
-                        validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"Invalid URL '") + unicode(source) + _(u"' entered.")))
+            if data.sources:
+                sources = list(filter(None, data.sources.split('\n')))
+                if len(sources) == 0:
+                    validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at least one source URL!")))
+                else:
+                    for source in sources:
+                        # Parse the string to see if it's a URL.  It has to, at least, have a path, which could
+                        # mean it's a relative `/static/` URL.
+                        _scheme, _netloc, path, _params, _qs, _fragment = urlparse(source)
+                        if path is None:
+                            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"Invalid URL '") + source + _(u"' entered.")))

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -47,6 +47,12 @@ class AudioFields(object):
         scope=Scope.settings
     )
 
+    transcript_url = String(
+        help="Transcript file URL",
+        default=None,
+        scope=Scope.settings
+    )
+
     start_time = Float(
         help="Start time in seconds",
         default=0.0,
@@ -83,3 +89,5 @@ class AudioFields(object):
                         _scheme, _netloc, path, _params, _qs, _fragment = urlparse(source)
                         if path is None:
                             validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"Invalid URL '") + source + _(u"' entered.")))
+        if data.transcript_file and data.transcript_url:
+            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at most one transcript source!")))

--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -1,3 +1,151 @@
-.audio-xblock audio {
+.audio-xblock {
   display: block;
+  margin-bottom: 4rem;
+}
+
+.mejs-container {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+.mejs-container .mejs-controls {
+  position: relative !important;
+}
+
+.mejs-captions-layer .mejs-layer {
+  width: 100% !important;
+}
+
+.mejs-captions-layer .mejs-captions-text {
+  white-space: normal;
+  word-wrap: break-word;
+  max-width: 40ch;
+  background-color: rgba(255, 255, 255, 0.8);
+  padding: 10px;
+  font-size: 18px;
+  line-height: 1.2;
+  text-align: center;
+  color: #000;
+  position: absolute;
+  transform: translateX(-50%);
+  top: 35px;
+  width: 100%;
+  left: 32rem;
+}
+
+.mejs-captions-position {
+  bottom: 50px;
+  left: 50% !important;
+  transform: translateX(-50%);
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.mejs-controls .mejs-button > button {
+  background: url('/static/css/controls.svg') no-repeat;
+}
+
+.mejs-controls .mejs-time-rail {
+  width: 84% !important;
+}
+
+.mejs-time-slider {
+  width: 83% !important;
+}
+
+.mejs-time-total, .mejs-time-loaded, .mejs-time-current, .mejs-time-handle, .mejs-time-float {
+  max-width: 100% !important;
+}
+
+.tab-container {
+  width: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+  height: calc(100% - 55px);
+  position: absolute;
+  overflow-y: scroll;
+  bottom: 0;
+  top: 0;
+}
+
+.tabcontent {
+  display: none;
+}
+
+.studio-xblock-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 25px;
+}
+
+.field label {
+  font-size: 14px;
+}
+
+.field input[type="file"],
+.field textarea {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.field input[type="text"] {
+  width: 20%;
+}
+
+.tab-container p {
+  font-size: small;
+}
+
+.field select {
+  width: 70px;
+}
+
+.save-button {
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.save-button:hover {
+  background-color: #45a049;
+}
+
+.radio-container {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.radio-container label {
+  display: flex;
+  align-items: center;
+  margin-right: 20px;
+}
+
+.radio-container input[type="radio"] {
+  margin-right: 8px;
+}
+
+.radio-group {
+  margin-bottom: 20px;
+}
+
+.bold-label {
+  font-weight: bold;
+}
+
+.time-fields {
+  display: flex;
+  flex-direction: column;
+  margin-top: 10px;
 }

--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -42,6 +42,10 @@
   justify-content: center;
 }
 
+.mejs-controls {
+    display: inline-block;
+}
+
 .mejs-controls .mejs-button > button {
   background: url('/static/css/controls.svg') no-repeat;
 }

--- a/audio/public/js/audio.js
+++ b/audio/public/js/audio.js
@@ -1,3 +1,58 @@
-function AudioBlock(runtime, context) {
-  $('audio').mediaelementplayer()
+function AudioBlock(runtime, element) {
+    const audioElement = $(element).find('audio')[0];
+    if (!audioElement || !audioElement.dataset) {
+        console.error("Audio element or dataset is undefined.");
+        return;
+    }
+
+    const startTime = parseFloat(audioElement.dataset.startTime) || 0;
+    const endTime = parseFloat(audioElement.dataset.endTime) || 0;
+
+    $(audioElement).mediaelementplayer({
+        features: ['playpause', 'progress', 'volume', 'tracks', 'fullscreen'],
+        startLanguage: 'en',
+        success: function(mediaElement, originalNode) {
+            mediaElement.setCurrentTime(startTime);
+
+            Object.defineProperty(mediaElement, 'duration', {
+                get: function() {
+                    return endTime - startTime;
+                }
+            });
+
+            mediaElement.addEventListener('timeupdate', function() {
+                if (endTime > 0 && mediaElement.currentTime >= endTime) {
+                    mediaElement.pause();
+                    mediaElement.setCurrentTime(startTime);
+                    mediaElement.stop();
+                }
+            });
+
+            mediaElement.addEventListener('play', function() {
+                if (mediaElement.currentTime < startTime || mediaElement.currentTime >= endTime) {
+                    mediaElement.setCurrentTime(startTime);
+                }
+            });
+
+            mediaElement.addEventListener('seeking', function() {
+                if (mediaElement.currentTime < startTime || (endTime > 0 && mediaElement.currentTime >= endTime)) {
+                    mediaElement.setCurrentTime(startTime);
+                }
+            });
+
+            mediaElement.addEventListener('loadedmetadata', function() {
+                if (endTime > 0) {
+                    mediaElement.setCurrentTime(startTime);
+                }
+            });
+
+            mediaElement.addEventListener('timeupdate', function() {
+                const playedPercent = (mediaElement.currentTime - startTime) / (endTime - startTime);
+                const progressBar = $(element).find('.mejs-time-current');
+                if (progressBar.length) {
+                    progressBar.css('width', (playedPercent * 100) + '%');
+                }
+            });
+        }
+    });
 }

--- a/audio/public/js/audio.js
+++ b/audio/public/js/audio.js
@@ -6,7 +6,7 @@ function AudioBlock(runtime, element) {
     }
 
     const startTime = parseFloat(audioElement.dataset.startTime) || 0;
-    const endTime = parseFloat(audioElement.dataset.endTime) || 0;
+    const endTime = parseFloat(audioElement.dataset.endTime) || audioElement.duration;
 
     $(audioElement).mediaelementplayer({
         features: ['playpause', 'progress', 'volume', 'tracks', 'fullscreen'],

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -1,7 +1,14 @@
 function AudioBlockStudio(runtime, element) {
+    $(element).find('.save-button').click(function(event) {
+        event.preventDefault();
+        $(element).find('form').submit();
+    });
+
     $(element).find('form').submit(function(event) {
         event.preventDefault();
         var data = new FormData($(this).get(0));
+        var description = $(element).find('#description').val();
+        data.append('description', description);
         runtime.notify('save', {state: 'start'});
 
         $.ajax({

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -1,0 +1,75 @@
+function AudioBlockStudio(runtime, element) {
+    $(element).find('form').submit(function(event) {
+        event.preventDefault();
+        var data = new FormData($(this).get(0));
+        runtime.notify('save', {state: 'start'});
+
+        $.ajax({
+            url: runtime.handlerUrl(element, 'studio_submit'),
+            type: 'POST',
+            data: data,
+            processData: false,
+            contentType: false,
+            success: function(response) {
+                runtime.notify('save', {state: 'end'});
+                window.location.reload();
+            }
+        });
+    });
+
+    $(element).find('.cancel-button').bind('click', function () {
+        if ('notify' in runtime) { //xblock workbench runtime does not have `notify` method
+            runtime.notify('cancel', {});
+        }
+    });
+
+    var sourcesField = document.getElementById('sources');
+    var embedUrlField = document.getElementById('embed_url');
+    var startTimeCheckbox = document.getElementById('start_time_checkbox');
+    var timeFields = document.getElementById('time_fields');
+
+    // Remove the existing openTab function and add the showContent function
+    window.showContent = function(contentType) {
+        var audioTab = document.getElementById('audioTab');
+        var podcastTab = document.getElementById('podcastTab');
+
+        if (contentType === 'audioTab') {
+            audioTab.style.display = 'block';
+            podcastTab.style.display = 'none';
+        } else if (contentType === 'podcastTab') {
+            podcastTab.style.display = 'block';
+            audioTab.style.display = 'none';
+        }
+    }
+
+    // Initialize the "Audio files" content by default
+    showContent('audioTab');
+    document.getElementById("audioRadio").checked = true;
+
+
+    // Handle mutual exclusivity
+    sourcesField.addEventListener('input', function() {
+        if (sourcesField.value.trim() !== '') {
+            embedUrlField.disabled = true;
+        } else {
+            embedUrlField.disabled = false;
+        }
+    });
+
+    embedUrlField.addEventListener('input', function() {
+        if (embedUrlField.value.trim() !== '') {
+            sourcesField.disabled = true;
+        } else {
+            sourcesField.disabled = false;
+        }
+    });
+
+    // Handle start time checkbox
+    startTimeCheckbox.addEventListener('change', function() {
+        if (startTimeCheckbox.checked) {
+            timeFields.style.display = "block";
+        } else {
+            timeFields.style.display = "none";
+        }
+    });
+}

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -1,8 +1,10 @@
+{% if description %}
+    <p>{{ description }}</p>
+{% endif %}
 {% if embed_url %}
     <iframe src="{{ embed_url }}" width="100%" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
 {% else %}
   <div id="{{ audio_id }}" class="audio-xblock">
-    <p>{{description}}</p>
     <audio preload="metadata" controls="controls" data-start-time="{{ start_time }}" data-end-time="{{ end_time }}">
       Your browser does not support native <code>audio</code> capabilities!
       {% for source, type in sources %}

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -1,15 +1,23 @@
-<div id="${audio_id}" class="audio-xblock">
-  <audio preload="metadata" controls="controls">
-    Your browser does not support native <code>audio</code> capabilities!
-    % for (source, type) in sources:
-    % if type is None:
-    <source src="${source}" />
-    % else:
-    <source src="${source}" type="${type}" />
-    % endif
-    % endfor
-  </audio>
-  % if allow_audio_download and audio_download_url:
-  <div class="audio-xblock-download"><a href="${audio_download_url}">Download audio</a></div>
-  % endif
-</div>
+{% if embed_url %}
+    <iframe src="{{ embed_url }}" width="100%" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+{% else %}
+  <div id="{{ audio_id }}" class="audio-xblock">
+    <p>{{description}}</p>
+    <audio preload="metadata" controls="controls" data-start-time="{{ start_time }}" data-end-time="{{ end_time }}">
+      Your browser does not support native <code>audio</code> capabilities!
+      {% for source, type in sources %}
+        {% if type is None %}
+          <source src="{{ source }}" />
+        {% else %}
+          <source src="{{ source }}" type="{{ type }}" />
+        {% endif %}
+      {% endfor %}
+      {% if transcript_file %}
+        <track kind="subtitles" src="{{ transcript_file }}" srclang="en" label="English" default/>
+      {% endif %}
+    </audio>
+    {% if allow_audio_download and audio_download_url %}
+      <div class="audio-xblock-download"><a href="{{ audio_download_url }}">Download audio</a></div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -1,0 +1,77 @@
+<div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
+    <div class="tab-container">
+        <div class="radio-group">
+            <label for="content_type">
+                <span class="bold-label">Select Audio Type:</span>
+            </label>
+            <div class="radio-container">
+                <label>
+                    <input type="radio" name="content_type" value="audio" onclick="showContent('audioTab')" id="audioRadio" checked>
+                    Audio file
+                </label>
+                <label>
+                    <input type="radio" name="content_type" value="podcast" onclick="showContent('podcastTab')" id="podcastRadio">
+                    Podcasts
+                </label>
+            </div>
+        </div>
+    
+        <div id="audioTab" class="tabcontent">
+            <form class="studio-xblock-form">
+                <div class="field">
+                    <label for="sources">Audio file URLs</label>
+                    <textarea id="sources" name="sources" {% if self.embed_url %}disabled{% endif %}>{{ self.sources }}</textarea>
+                    <p class="help">Place each URL on a new line.</p>
+                </div>
+                <div class="field">
+                    <label for="transcript_file">Audio transcript</label>
+                    <input type="file" id="transcript_file" name="transcript_file" />
+                    <p class="help">Only WebVTT format is supported.</p>
+                </div>
+                <div class="field">
+                    <label for="allow_audio_download">Allow audio download</label>
+                    <select id="allow_audio_download" name="allow_audio_download">
+                        <option value="true" {% if self.allow_audio_download %}selected{% endif %}>Yes</option>
+                        <option value="false" {% if not self.allow_audio_download %}selected{% endif %}>No</option>
+                    </select>
+                    <p class="help">You can allow students to download the source file of this audio.</p>
+                </div>
+                <div class="checkbox-container">
+                    <input type="checkbox" id="start_time_checkbox" name="start_time_checkbox" {% if self.start_time or self.end_time %}checked{% endif %}/>
+                    <label for="start_time_checkbox">Set start and end time</label>
+                </div>
+
+                <div class="time-fields" id="time_fields" {% if not self.start_time and not self.end_time %}style="display:none"{% endif %}>
+                    <div class="field">
+                        <label for="start_time">Start time</label>
+                        <input type="text" id="start_time" name="start_time" value="{{ self.start_time|default:"00:00" }}" />
+                    </div>
+                    <div class="field">
+                        <label for="end_time">End time</label>
+                        <input type="text" id="end_time" name="end_time" value="{{ self.end_time|default:"00:00" }}" />
+                    </div>
+                </div>
+            </form>
+        </div>
+    
+        <div id="podcastTab" class="tabcontent">
+            <form class="studio-xblock-form">
+                <div class="field">
+                    <label for="embed_url">Podcast embed URL</label>
+                    <textarea id="embed_url" name="embed_url" {% if self.sources %}disabled{% endif %}>{{ self.embed_url }}</textarea>
+                    <p class="help">Enter the embed URL for a third-party podcast (e.g., Spotify, SoundCloud).</p>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="xblock-actions">
+        <ul>
+          <li class="action-item hidden">
+            <a href="#" class="button action-primary save-button">Save</a>
+          </li>
+          <li class="action-item">
+            <a href="#" class="button cancel-button">Cancel</a>
+          </li>
+        </ul>
+      </div>
+</div>

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -1,5 +1,10 @@
 <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
     <div class="tab-container">
+        <div class="field">
+            <label for="description">Description</label>
+            <textarea id="description" name="description">{{ self.description }}</textarea>
+            <p class="help">Add an optional description to display above the audio player.</p>
+        </div>
         <div class="radio-group">
             <label for="content_type">
                 <span class="bold-label">Select Audio Type:</span>

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -34,6 +34,11 @@
                     <p class="help">Only WebVTT format is supported.</p>
                 </div>
                 <div class="field">
+                    <label for="transcript_url">Audio transcript URL</label>
+                    <input type="text" id="transcript_url" name="transcript_url" {% if self.transcript_url %}value="{{ self.transcript_url }}"{% endif %} />
+                    <p class="help">Only WebVTT format is supported.</p>
+                </div>
+                <div class="field">
                     <label for="allow_audio_download">Allow audio download</label>
                     <select id="allow_audio_download" name="allow_audio_download">
                         <option value="true" {% if self.allow_audio_download %}selected{% endif %}>Yes</option>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
--e git://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     packages=['audio'],
     install_requires=[
         'XBlock',
-        'xblock-utils',
     ],
     entry_points={
         'xblock.v1': BLOCKS,


### PR DESCRIPTION

## Description

Before, the download link was pushed to the right
and split over multiple lines in the studio view.

Now it displays on a single line, aligned to the left,
and is consistent between student and studio views.

<details>
<summary>screenshots</summary>

Before:
<img width="1329" height="186" alt="1754459800" src="https://github.com/user-attachments/assets/a59975eb-ffc6-42ae-bb64-73f7ba18a886" />

After:
<img width="1333" height="150" alt="1754459810" src="https://github.com/user-attachments/assets/b916bff4-7f15-4cc8-8b1c-c859a6971608" />

</details>

NOTE: this is built on top of the other two open PRs in this repo - we should merge them first.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9935

## Testing instructions

- create an audio component in studio, with the "allow audio download" set to "yes"
- view the component in studio and verify the "Download audio" link is rendered on a single line, left aligned.
- view the component in the live course (student view), and verify the  "Download audio" link is rendered on a single line, left aligned as well.

## Deadline

"None"