### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ You can enable the XBlock in Studio through `Advanced Settings`.
 1. From the main page of a specific course, navigate to `Settings -> Advanced Settings` from the top menu.
 2. Check for the `advanced_modules` policy key, and add `"audio"` to the policy value list.
 3. Click the "Save changes" button.
+
+## Configuration
+
+Transcript files will be uploaded to the default Django storage.
+If you wish to customise where the transcript files are uploaded,
+set a custom storage config in the [STORAGES](https://docs.djangoproject.com/en/5.2/ref/settings/#storages) setting,
+with the key `xblock_audio_storage`.

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -3,8 +3,8 @@ from functools import partial
 import logging
 import pkg_resources
 import os
-from uuid import uuid4
 from django.conf import settings
+from django.utils.text import get_valid_filename
 from django.core.files import File
 from webob.response import Response
 
@@ -160,8 +160,9 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             transcript_file = data['transcript_file']
 
             # generate a safe path for the transcript file
-            loc = self.location
-            file_path = f"{loc.org}/{loc.course}/{loc.block_type}/{loc.block_id}/{uuid4()}.vtt"
+            name = get_valid_filename(transcript_file.filename)
+            safe_usage_key = get_valid_filename(self.usage_key)
+            file_path = f"{safe_usage_key}/transcripts/{name}"
             storage.save(file_path, File(transcript_file.file))
             self.transcript_file = file_path
 

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
+from functools import partial
 import logging
 import pkg_resources
 import os
+from uuid import uuid4
 from django.conf import settings
+from django.core.files import File
 from webob.response import Response
 
 from xblock.core import XBlock
 from xblock.fragment import Fragment
 
 from .fields import AudioFields
-from .utils import get_path_mimetype
+from .utils import get_path_mimetype, get_storage_backend
 
 try:
     from xblock.utils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
@@ -60,6 +63,15 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         except ValueError:
             return 0.0
 
+    def get_resolved_transcript_url(self):
+        """
+        Return the transcript url to be used (if present) for the xblock.
+        """
+        if self.transcript_url:
+            return self.transcript_url
+        elif self.transcript_file:
+            return self.runtime.handler_url(self, 'transcript_file_handler')
+
     def studio_view(self, context):
         """
         View for editing the XBlock settings in Studio
@@ -69,7 +81,9 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'description': self.description,
                 'sources': self.sources,
                 'embed_url': self.embed_url,
-                'transcript_url': self.transcript_url,
+                'transcript_url': self.transcript_url or "",
+                'transcript_file_url': self.runtime.handler_url(self, 'transcript_file_handler') if self.transcript_file else "",
+                'transcript_file_name': os.path.basename(self.transcript_file) if self.transcript_file else "",
                 'allow_audio_download': self.allow_audio_download,
                 'start_time': convert_seconds_to_time(self.start_time),
                 'end_time': convert_seconds_to_time(self.end_time),
@@ -81,7 +95,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/audio_edit.js'))
         fragment.initialize_js('AudioBlockStudio')
         return fragment
-
 
     def student_view(self, context):
         """
@@ -96,6 +109,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             type = get_path_mimetype(source)
             annotated_sources.append((source, type))
 
+        resolved_transcript_url = self.get_resolved_transcript_url()
         html = self.loader.render_django_template(
             'templates/html/audio.html', {
                 'audio_id': self.audio_id,
@@ -103,7 +117,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'allow_audio_download': self.allow_audio_download,
                 'audio_download_url': audio_download_url,
                 'description': self.description,
-                'transcript_file': self.transcript_url or self.transcript_file,
+                'resolved_transcript_url': resolved_transcript_url,
                 'start_time': self.start_time,
                 'end_time': self.end_time,
                 'embed_url': self.embed_url
@@ -134,15 +148,39 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         self.embed_url = data.get('embed_url', '') if not data.get('sources', '') else ''
         self.transcript_url = data.get('transcript_url')
 
-        if 'transcript_file' in request.params and hasattr(request.params['transcript_file'], 'file'):
-            transcript_file = request.params['transcript_file']
-            file_name = transcript_file.filename
-            file_path = os.path.join(settings.MEDIA_ROOT, 'transcripts', file_name)
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            with open(file_path, 'wb') as f:
-                f.write(transcript_file.file.read())
-            self.transcript_file = f'/media/transcripts/{file_name}'
-        else:
+        storage = get_storage_backend()
+        will_upload_transcript_file = 'transcript_file' in data and hasattr(data.get('transcript_file'), 'file')
+
+        if data.get("delete_transcript_file", "") == "on" or will_upload_transcript_file:
+            if self.transcript_file and storage.exists(self.transcript_file):
+                storage.delete(self.transcript_file)
             self.transcript_file = None
 
+        if will_upload_transcript_file:
+            transcript_file = data['transcript_file']
+
+            # generate a safe path for the transcript file
+            loc = self.location
+            file_path = f"{loc.org}/{loc.course}/{loc.block_type}/{loc.block_id}/{uuid4()}.vtt"
+            storage.save(file_path, File(transcript_file.file))
+            self.transcript_file = file_path
+
         return Response(json_body={'result': 'success'})
+
+    @XBlock.handler
+    def transcript_file_handler(self, request, suffix=''):
+        BLOCK_SIZE = 2 ** 10 * 8  # 8kb
+        storage = get_storage_backend()
+        path = self.transcript_file
+
+        if path:
+            try:
+                return Response(
+                    app_iter=iter(partial(storage.open(path).read, BLOCK_SIZE), b""),
+                    content_type='text/vtt',
+                    content_disposition=f"attachment; filename*=UTF-8''{os.path.basename(path)}",
+                )
+            except OSError:
+                pass
+
+        return Response("file not found", status_code=404)

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -25,6 +25,14 @@ except ModuleNotFoundError:  # For compatibility with releases older than Quince
 
 log = logging.getLogger(__name__)
 
+
+def convert_seconds_to_time(seconds):
+    """Convert total seconds to the format MM:SS."""
+    # It's stored as a float in the xblock, but treated as an int.
+    seconds = int(seconds)
+    return f"{seconds // 60:02}:{seconds % 60:02}"
+
+
 @XBlock.needs('i18n')
 class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMixin, XBlock):
     icon_class = 'other'
@@ -52,15 +60,21 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         except ValueError:
             return 0.0
 
-
     def studio_view(self, context):
         """
         View for editing the XBlock settings in Studio
         """
         html = self.loader.render_django_template(
             'templates/html/audio_edit.html', {
-                'self': self
-            })
+                'description': self.description,
+                'sources': self.sources,
+                'embed_url': self.embed_url,
+                'transcript_url': self.transcript_url,
+                'allow_audio_download': self.allow_audio_download,
+                'start_time': convert_seconds_to_time(self.start_time),
+                'end_time': convert_seconds_to_time(self.end_time),
+            }
+        )
 
         fragment = Fragment(html)
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/audio.css'))

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -90,4 +90,4 @@ class AudioFields(object):
                         if path is None:
                             validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"Invalid URL '") + source + _(u"' entered.")))
         if data.transcript_file and data.transcript_url:
-            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at most one transcript source!")))
+            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You may only specify a single transcript source (an uploaded file OR a url). Please remove one to continue.")))

--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -73,10 +73,6 @@
   top: 0;
 }
 
-.tabcontent {
-  display: none;
-}
-
 .studio-xblock-form {
   display: flex;
   flex-direction: column;

--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -42,6 +42,10 @@
   justify-content: center;
 }
 
+.mejs-controls {
+    display: inline-block;
+}
+
 .mejs-controls .mejs-button > button {
   background: url('/static/css/controls.svg') no-repeat;
 }

--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -1,6 +1,7 @@
 .audio-xblock {
   display: block;
   margin-bottom: 4rem;
+  margin-top: 4rem;
 }
 
 .mejs-container {
@@ -60,6 +61,12 @@
 
 .mejs-time-total, .mejs-time-loaded, .mejs-time-current, .mejs-time-handle, .mejs-time-float {
   max-width: 100% !important;
+}
+
+.mejs-captions-selector label {
+    text-shadow: none;
+    margin-bottom: 0;
+    color: white;
 }
 
 .tab-container {

--- a/audio/public/js/audio.js
+++ b/audio/public/js/audio.js
@@ -7,7 +7,23 @@ function AudioBlock(runtime, element) {
 
     // these default to 0.0 if unset
     const startTime = parseFloat(audioElement.dataset.startTime);
-    const endTime = parseFloat(audioElement.dataset.endTime);
+
+    // calculate end time on the fly,
+    // because it should be within the actual audio duration,
+    // and the audio duration may not be available when the script initially runs.
+    function getEndTime() {
+      const endTime = parseFloat(audioElement.dataset.endTime);
+      if (endTime == 0.0) {
+        return 0.0;
+      }
+
+      const duration = audioElement.duration;
+      if (!Number.isNaN(duration)) {
+        return Math.min(duration, endTime);
+      }
+
+      return endTime;
+    }
 
     $(audioElement).mediaelementplayer({
         features: ['playpause', 'progress', 'volume', 'tracks', 'fullscreen'],
@@ -16,6 +32,7 @@ function AudioBlock(runtime, element) {
             mediaElement.setCurrentTime(startTime);
 
             mediaElement.addEventListener('timeupdate', function() {
+                const endTime = getEndTime();
                 if (endTime > 0 && mediaElement.currentTime >= endTime) {
                     mediaElement.pause();
                     mediaElement.setCurrentTime(startTime);
@@ -24,24 +41,28 @@ function AudioBlock(runtime, element) {
             });
 
             mediaElement.addEventListener('play', function() {
+                const endTime = getEndTime();
                 if (mediaElement.currentTime < startTime || (endTime > 0 && mediaElement.currentTime >= endTime)) {
                     mediaElement.setCurrentTime(startTime);
                 }
             });
 
             mediaElement.addEventListener('seeking', function() {
+                const endTime = getEndTime();
                 if (mediaElement.currentTime < startTime || (endTime > 0 && mediaElement.currentTime >= endTime)) {
                     mediaElement.setCurrentTime(startTime);
                 }
             });
 
             mediaElement.addEventListener('loadedmetadata', function() {
+                const endTime = getEndTime();
                 if (endTime > 0) {
                     mediaElement.setCurrentTime(startTime);
                 }
             });
 
             mediaElement.addEventListener('timeupdate', function() {
+                const endTime = getEndTime();
                 if (endTime > 0) {
                     const playedPercent = (mediaElement.currentTime - startTime) / (endTime - startTime);
                     const progressBar = $(element).find('.mejs-time-current');

--- a/audio/public/js/audio.js
+++ b/audio/public/js/audio.js
@@ -5,20 +5,15 @@ function AudioBlock(runtime, element) {
         return;
     }
 
-    const startTime = parseFloat(audioElement.dataset.startTime) || 0;
-    const endTime = parseFloat(audioElement.dataset.endTime) || audioElement.duration;
+    // these default to 0.0 if unset
+    const startTime = parseFloat(audioElement.dataset.startTime);
+    const endTime = parseFloat(audioElement.dataset.endTime);
 
     $(audioElement).mediaelementplayer({
         features: ['playpause', 'progress', 'volume', 'tracks', 'fullscreen'],
         startLanguage: 'en',
         success: function(mediaElement, originalNode) {
             mediaElement.setCurrentTime(startTime);
-
-            Object.defineProperty(mediaElement, 'duration', {
-                get: function() {
-                    return endTime - startTime;
-                }
-            });
 
             mediaElement.addEventListener('timeupdate', function() {
                 if (endTime > 0 && mediaElement.currentTime >= endTime) {
@@ -29,7 +24,7 @@ function AudioBlock(runtime, element) {
             });
 
             mediaElement.addEventListener('play', function() {
-                if (mediaElement.currentTime < startTime || mediaElement.currentTime >= endTime) {
+                if (mediaElement.currentTime < startTime || (endTime > 0 && mediaElement.currentTime >= endTime)) {
                     mediaElement.setCurrentTime(startTime);
                 }
             });
@@ -47,10 +42,12 @@ function AudioBlock(runtime, element) {
             });
 
             mediaElement.addEventListener('timeupdate', function() {
-                const playedPercent = (mediaElement.currentTime - startTime) / (endTime - startTime);
-                const progressBar = $(element).find('.mejs-time-current');
-                if (progressBar.length) {
-                    progressBar.css('width', (playedPercent * 100) + '%');
+                if (endTime > 0) {
+                    const playedPercent = (mediaElement.currentTime - startTime) / (endTime - startTime);
+                    const progressBar = $(element).find('.mejs-time-current');
+                    if (progressBar.length) {
+                        progressBar.css('width', (playedPercent * 100) + '%');
+                    }
                 }
             });
         }

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -7,8 +7,6 @@ function AudioBlockStudio(runtime, element) {
     $(element).find('form').submit(function(event) {
         event.preventDefault();
         var data = new FormData($(this).get(0));
-        var description = $(element).find('#description').val();
-        data.append('description', description);
         runtime.notify('save', {state: 'start'});
 
         $.ajax({
@@ -19,7 +17,6 @@ function AudioBlockStudio(runtime, element) {
             contentType: false,
             success: function(response) {
                 runtime.notify('save', {state: 'end'});
-                window.location.reload();
             }
         });
     });
@@ -30,53 +27,35 @@ function AudioBlockStudio(runtime, element) {
         }
     });
 
-    var sourcesField = document.getElementById('sources');
-    var embedUrlField = document.getElementById('embed_url');
-    var startTimeCheckbox = document.getElementById('start_time_checkbox');
-    var timeFields = document.getElementById('time_fields');
+    window.audioSwitchType = function(tab) {
+        if (tab === 'audio-tab') {
+            $('#audio-tab').show();
+            $('#podcast-tab').hide();
 
-    // Remove the existing openTab function and add the showContent function
-    window.showContent = function(contentType) {
-        var audioTab = document.getElementById('audioTab');
-        var podcastTab = document.getElementById('podcastTab');
+            // Reset podcast-tab fields when switching to audio type
+            $('#embed-url').val('');
+        } else if (tab === 'podcast-tab') {
+            $('#audio-tab').hide();
+            $('#podcast-tab').show();
 
-        if (contentType === 'audioTab') {
-            audioTab.style.display = 'block';
-            podcastTab.style.display = 'none';
-        } else if (contentType === 'podcastTab') {
-            podcastTab.style.display = 'block';
-            audioTab.style.display = 'none';
+            // Reset audio-tab fields when switching to podcast type
+            $('#start-time').val('00:00');
+            $('#end-time').val('00:00');
+            $('#sources').val('');
+            $('#transcript-file').val('');
+            $('#transcript-url').val('');
+            $('#allow-audio-download').val('true');
+            $('#start-time-checkbox').prop('checked', false);
         }
     }
 
-    // Initialize the "Audio files" content by default
-    showContent('audioTab');
-    document.getElementById("audioRadio").checked = true;
-
-
-    // Handle mutual exclusivity
-    sourcesField.addEventListener('input', function() {
-        if (sourcesField.value.trim() !== '') {
-            embedUrlField.disabled = true;
+    $('#start-time-checkbox').on('change', function() {
+        if ($('#start-time-checkbox').is(':checked')) {
+            $('#time-fields').show();
         } else {
-            embedUrlField.disabled = false;
-        }
-    });
-
-    embedUrlField.addEventListener('input', function() {
-        if (embedUrlField.value.trim() !== '') {
-            sourcesField.disabled = true;
-        } else {
-            sourcesField.disabled = false;
-        }
-    });
-
-    // Handle start time checkbox
-    startTimeCheckbox.addEventListener('change', function() {
-        if (startTimeCheckbox.checked) {
-            timeFields.style.display = "block";
-        } else {
-            timeFields.style.display = "none";
+            $('#time-fields').hide();
+            $('#start-time').val('00:00');
+            $('#end-time').val('00:00');
         }
     });
 }

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -14,8 +14,8 @@
           <source src="{{ source }}" type="{{ type }}" />
         {% endif %}
       {% endfor %}
-      {% if transcript_file %}
-        <track kind="subtitles" src="{{ transcript_file }}" srclang="en" label="English" default/>
+      {% if resolved_transcript_url %}
+        <track kind="subtitles" src="{{ resolved_transcript_url }}" srclang="en" label="English" default/>
       {% endif %}
     </audio>
     {% if allow_audio_download and audio_download_url %}

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -19,7 +19,7 @@
       {% endif %}
     </audio>
     {% if allow_audio_download and audio_download_url %}
-      <div class="audio-xblock-download"><a href="{{ audio_download_url }}">Download audio</a></div>
+      <div class="audio-xblock-download"><a href="{{ audio_download_url }}" target="_blank" rel="noopener" download>Download audio</a></div>
     {% endif %}
   </div>
 {% endif %}

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -30,7 +30,16 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <p class="help">Enter the URL for the audio here. To improve compatibility with a range of browsers, you may wish to provide multiple versions of the same audio (for example, an MP3 version and an Ogg Vorbis version). If so, place each URL on a new line.</p>
             </div>
             <div class="field">
-                <label for="transcript-file">Audio transcript</label>
+                <p class="help">If you wish to add a transcript below, please either upload a file or provide a URL (but not both).</p>
+                <label for="transcript-file">Audio transcript file</label>
+                {% if transcript_file_url %}
+                <div>
+                    <small>Currently:</small>
+                    <a href="{{ transcript_file_url }}">{{ transcript_file_name }}</a>
+                    <input type="checkbox" id="delete-transcript-file" name="delete_transcript_file" />
+                    <label for="delete-transcript-file">Delete</label>
+                </div>
+                {% endif %}
                 <input type="file" id="transcript-file" name="transcript_file" />
                 <p class="help">Only WebVTT format is supported.</p>
             </div>

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -25,8 +25,9 @@
         <div id="audio-tab" class="tabcontent" {% if not sources and embed_url %}style="display: none;"{% endif %}>
             <div class="field">
                 <label for="sources">Audio file URLs</label>
-                <textarea id="sources" name="sources">{{ sources }}</textarea>
-                <p class="help">Place each URL on a new line.</p>
+                <textarea id="sources" name="sources" placeholder="https://example.com/bird-calls.mp3
+https://example.com/bird-calls.ogg">{{ sources }}</textarea>
+                <p class="help">Enter the URL for the audio here. To improve compatibility with a range of browsers, you may wish to provide multiple versions of the same audio (for example, an MP3 version and an Ogg Vorbis version). If so, place each URL on a new line.</p>
             </div>
             <div class="field">
                 <label for="transcript-file">Audio transcript</label>

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -1,79 +1,76 @@
 <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
-    <div class="tab-container">
+    <form class="studio-xblock-form tab-container">
         <div class="field">
             <label for="description">Description</label>
-            <textarea id="description" name="description">{{ self.description }}</textarea>
+            <textarea id="description" name="description">{{ description }}</textarea>
             <p class="help">Add an optional description to display above the audio player.</p>
         </div>
+
         <div class="radio-group">
             <label for="content_type">
                 <span class="bold-label">Select Audio Type:</span>
             </label>
             <div class="radio-container">
                 <label>
-                    <input type="radio" name="content_type" value="audio" onclick="showContent('audioTab')" id="audioRadio" checked>
+                    <input type="radio" name="content_type" value="audio" onclick="audioSwitchType('audio-tab')" id="audio-radio" {% if sources or not embed_url %}checked{% endif %}>
                     Audio file
                 </label>
                 <label>
-                    <input type="radio" name="content_type" value="podcast" onclick="showContent('podcastTab')" id="podcastRadio">
+                    <input type="radio" name="content_type" value="podcast" onclick="audioSwitchType('podcast-tab')" id="podcast-radio" {% if not sources and embed_url %}checked{% endif %}>
                     Podcasts
                 </label>
             </div>
         </div>
-    
-        <div id="audioTab" class="tabcontent">
-            <form class="studio-xblock-form">
-                <div class="field">
-                    <label for="sources">Audio file URLs</label>
-                    <textarea id="sources" name="sources" {% if self.embed_url %}disabled{% endif %}>{{ self.sources }}</textarea>
-                    <p class="help">Place each URL on a new line.</p>
-                </div>
-                <div class="field">
-                    <label for="transcript_file">Audio transcript</label>
-                    <input type="file" id="transcript_file" name="transcript_file" />
-                    <p class="help">Only WebVTT format is supported.</p>
-                </div>
-                <div class="field">
-                    <label for="transcript_url">Audio transcript URL</label>
-                    <input type="text" id="transcript_url" name="transcript_url" {% if self.transcript_url %}value="{{ self.transcript_url }}"{% endif %} />
-                    <p class="help">Only WebVTT format is supported.</p>
-                </div>
-                <div class="field">
-                    <label for="allow_audio_download">Allow audio download</label>
-                    <select id="allow_audio_download" name="allow_audio_download">
-                        <option value="true" {% if self.allow_audio_download %}selected{% endif %}>Yes</option>
-                        <option value="false" {% if not self.allow_audio_download %}selected{% endif %}>No</option>
-                    </select>
-                    <p class="help">You can allow students to download the source file of this audio.</p>
-                </div>
-                <div class="checkbox-container">
-                    <input type="checkbox" id="start_time_checkbox" name="start_time_checkbox" {% if self.start_time or self.end_time %}checked{% endif %}/>
-                    <label for="start_time_checkbox">Set start and end time</label>
-                </div>
 
-                <div class="time-fields" id="time_fields" {% if not self.start_time and not self.end_time %}style="display:none"{% endif %}>
-                    <div class="field">
-                        <label for="start_time">Start time</label>
-                        <input type="text" id="start_time" name="start_time" value="{{ self.start_time|default:"00:00" }}" />
-                    </div>
-                    <div class="field">
-                        <label for="end_time">End time</label>
-                        <input type="text" id="end_time" name="end_time" value="{{ self.end_time|default:"00:00" }}" />
-                    </div>
-                </div>
-            </form>
-        </div>
-    
-        <div id="podcastTab" class="tabcontent">
-            <form class="studio-xblock-form">
+        <div id="audio-tab" class="tabcontent" {% if not sources and embed_url %}style="display: none;"{% endif %}>
+            <div class="field">
+                <label for="sources">Audio file URLs</label>
+                <textarea id="sources" name="sources">{{ sources }}</textarea>
+                <p class="help">Place each URL on a new line.</p>
+            </div>
+            <div class="field">
+                <label for="transcript-file">Audio transcript</label>
+                <input type="file" id="transcript-file" name="transcript_file" />
+                <p class="help">Only WebVTT format is supported.</p>
+            </div>
+            <div class="field">
+                <label for="transcript-url">Audio transcript URL</label>
+                <input type="text" id="transcript-url" name="transcript_url" value="{{ transcript_url }}" />
+                <p class="help">Only WebVTT format is supported.</p>
+            </div>
+            <div class="field">
+                <label for="allow-audio-download">Allow audio download</label>
+                <select id="allow-audio-download" name="allow_audio_download">
+                    <option value="true" {% if allow_audio_download %}selected{% endif %}>Yes</option>
+                    <option value="false" {% if not allow_audio_download %}selected{% endif %}>No</option>
+                </select>
+                <p class="help">You can allow students to download the source file of this audio.</p>
+            </div>
+            <div class="checkbox-container">
+                <input type="checkbox" id="start-time-checkbox" name="start_time_checkbox" {% if start_time != '00:00' or end_time != '00:00' %}checked{% endif %}/>
+                <label for="start-time-checkbox">Set start and end time</label>
+            </div>
+
+            <div class="time-fields" id="time-fields" {% if start_time == '00:00' and end_time == '00:00' %}style="display:none"{% endif %}>
                 <div class="field">
-                    <label for="embed_url">Podcast embed URL</label>
-                    <textarea id="embed_url" name="embed_url" {% if self.sources %}disabled{% endif %}>{{ self.embed_url }}</textarea>
-                    <p class="help">Enter the embed URL for a third-party podcast (e.g., Spotify, SoundCloud).</p>
+                    <label for="start-time">Start time</label>
+                    <input type="text" id="start-time" name="start_time" value="{{ start_time }}" />
                 </div>
-            </form>
+                <div class="field">
+                    <label for="end-time">End time</label>
+                    <input type="text" id="end-time" name="end_time" value="{{ end_time }}" />
+                </div>
+            </div>
         </div>
-    </div>
+
+        <div id="podcast-tab" class="tabcontent" {% if sources or not embed_url %}style="display: none;"{% endif %}>
+            <div class="field">
+                <label for="embed-url">Podcast embed URL</label>
+                <textarea id="embed-url" name="embed_url">{{ embed_url }}</textarea>
+                <p class="help">Enter the embed URL for a third-party podcast (e.g., Spotify, SoundCloud).</p>
+            </div>
+        </div>
+    </form>
     <div class="xblock-actions">
         <ul>
           <li class="action-item hidden">

--- a/audio/utils.py
+++ b/audio/utils.py
@@ -1,3 +1,8 @@
+from django.conf import settings
+from django.core.files.storage import default_storage as django_default_storage
+from django.core.files.storage import storages
+
+
 def get_path_mimetype(path):
     ipath = path.lower()
     if ipath.endswith(".mp3"):
@@ -12,3 +17,10 @@ def get_path_mimetype(path):
         return "audio/mp4"
 
     return None
+
+
+def get_storage_backend():
+    storages_config = getattr(settings, "STORAGES", {})
+    if "xblock_audio_storage" in storages_config:
+        return storages["xblock_audio_storage"]
+    return django_default_storage


### PR DESCRIPTION
## Description

This fixes a subset of the reported issues found on the `wgu-release` branch (checked items have been addressed in this PR, unchecked items are still to discuss and work on):

- [x] 1. Progress slider not moving even though the audio is playing.
- [x] 2. "Download audio" link is pushed to the right and split over multiple lines
- [x] 3. Mute UI doesn't update when toggling mute
- [x] 4. Progress slider doesn't reach the end if an end time is set that's longer than the actual audio play time.
- [x] 5. Re-saving the xblock results in data loss.
- [x] 6. The multiple audio urls feature is confusing.
- [ ] 7. Sometimes the audio controls disappear, leaving a black box (I can't reliably reproduce this).
- [x] 8. transcript files are uploaded to /openedx/media/transcripts/ (they should be uploaded to a standard persistent storage)
- [x] 9. Uploaded transcript file is lost on re-save.
- [x] 10. The UI for changing the transcript needs improvement
- [x] 11. uploaded transcripts will override the previous one (ie. a transcript uploaded for another instance of the audio xblock) if they have the same file name
- [x] 12. If a new transcript is uploaded, the old one still remains on disk. (as an aside: do we want to support deleting a transcript as well?)
- [x] 13. the audio download link (if enabled) doesn't necessarily download - it may just open in the browser as an embedded audio player
- [x] 14. Podcast field is disabled if the audio file field is populated, and vice-verse. (UX needs improving)

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9935

## Testing instructions

### Fix for: "Download audio" link is pushed to the right and split over multiple lines

- create an audio component in studio, with the "allow audio download" set to "yes"
- view the component in studio and verify the "Download audio" link is rendered on a single line, left aligned.
- view the component in the live course (student view), and verify the  "Download audio" link is rendered on a single line, left aligned as well.

### Fix for: issues with mute button and progress slider

- create an audio component in studio, with no start or end time set
- play the audio
- click the mute button a few times while it's playing
- verify the mute/unmute actions work as expected, and the UI correctly displays the mute/unmute status
- verify the play progress slider correctly displays the play progress as expected
- create another audio component in studio, with valid start and end times set (0 < start time < end time  < total duration)
- play the audio
- verify the audio begins playing at the set start time
- when it reaches the end time, verify the audio returns to the start time and stops playing
- verify the play progress bar displayed the progress as if the clipped area was the real start and end (ie. the progress bar starts at the far left, and ends at the far right)
- experiment with seeking the audio to before the start time and after the end time
- there are other minor known issues with this, but for this purpose, verify the audio is bounced to the set start time whenever you go past the set bounds.

### Fix for: podcast/audio file field disabled if the other is set

- create an audio component in studio
- set it to "audio file" type and upload an audio file and save it
- edit the audio component again
- switch to the podcasts type
- verify you can enter a podcast embed url and successfully save it.

Note that switching between audio file and podcasts will clear the data from the now-inactive tab. Not sure if that is desired or not. It makes for a smooth experience, but could result in unexpected data loss if a user accidentally switches tabs before saving.

### Fix for: re-saving the xblock results in data loss

- create an audio component in studio, setting several fields
- save
- click to edit the block again
- don't modify any fields
- click "save"
- verify that nothing has changed
- try editing and saving a few more times, with different data inputs
- verify data is saved as expected.

### Fix for: confusing multiple urls for audio file

- create an audio component in studio
- in the editor, consider the placeholder and help text for the audio file urls:
- verify the purpose is clear

### Fix for: transcript uploaded to ephemeral path

- create an audio component in studio
- in the audio component editor, upload a transcript file
- verify the file is uploaded to the default storage location (in a Tutor devstack, this should be /openedx/media/ in the cms and lms shell (volume backed) - this matches the MEDIA_ROOT django setting)
- verify the transcript displays when playing the audio component

### Fix for: transcript lost on re-save

- use the audio component with an uploaded transcript file (from the previous step)
- edit the component in studio, but don't make any changes
- save the component
- verify the transcript is still present

### Fix for: bad UI for transcript selector

- use the audio component with an uploaded transcript file (from the previous step)
- use the transcript selector (the 'CC' button on the media player)
- verify the controls are all visible (not cut off at the top as it was before), readable, and accessible

See screenshot of it fixed for reference:

<img width="382" height="285" alt="1754976786" src="https://github.com/user-attachments/assets/34bafdf8-d826-401d-ba29-4901cf0f3607" />

### Fix for: if a new transcript is uploaded, the one one is still kept on disk

- use the audio component with an uploaded transcript file (from the previous step)
- locate the transcript file on disk (somewhere in /openedx/media/ in a Tutor devstack)
- edit the audio component, uploading a new transcript file
- verify the old transcript file is no longer present on disk
- verify the new transcript file saved successfully, and is visible when the audio is played

### Delete transcript functionality

- use the audio component with an uploaded transcript file (from the previous step)
- edit the audio component: delete the transcript file (using the Delete checkbox)
- save
- verify the transcript file is no longer present on disk
- verify no transcript is available when playing the audio

### Fix for: audio download link doesn't download

NOTE: there isn't a reliable fix for this - it's not possible here to force the browser to download the file instead of embedding it. We make some improvements here though:
- Add the "download" attribute, to ask the browser to download instead.
      Note that this only works for same origin urls.
- Add the target="_blank" attribute to open in a new tab.
      This avoids getting navigated away and losing your work.

Testing instructions:
- create an audio component with "allow audio download" set to "yes"
- save and view the audio
- click the "download audio" link
- verify the file opens in a new tab/window (it will likely be embedded by the browser still)
- verify the link has the "download" attribute set (check the html source).
- (optional): The download attribute only works for same-origin files - you can test the download attribute by uploading an audio file to studio, and adding that url to the audio component. Click the "download audio" link and verify the browser downloads the file instead of displaying it embedded.

### Fix for: progress slider doesn't reach the end if end time is longer than the audio duration

- create an audio component
- set an end time to something very large, much larger than the audio duration (eg. 500 hours)
- play the audio
- verify the progress slider updates as expected (ie. proportional to the actual play time)
- also test with no end time set, and with an end time somewhat shorter than the actual audio duration

## Deadline

None

## Other information

The `wgu-release` branch (that this PR targets) reflects the actual state of what is deployed. This `wgu-release` branch includes cherry picks of the following PRs (at time of writing):

- #1
- #3