### PR TITLE
feat: remove download audio link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ You can enable the XBlock in Studio through `Advanced Settings`.
 1. From the main page of a specific course, navigate to `Settings -> Advanced Settings` from the top menu.
 2. Check for the `advanced_modules` policy key, and add `"audio"` to the policy value list.
 3. Click the "Save changes" button.
+
+## Configuration
+
+Transcript files will be uploaded to the default Django storage.
+If you wish to customise where the transcript files are uploaded,
+set a custom storage config in the [STORAGES](https://docs.djangoproject.com/en/5.2/ref/settings/#storages) setting,
+with the key `xblock_audio_storage`.

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -43,7 +43,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
 
     editable_fields = (
         'sources',
-        'allow_audio_download',
         'description',
         'transcript_file',
         'transcript_url',
@@ -84,7 +83,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'transcript_url': self.transcript_url or "",
                 'transcript_file_url': self.runtime.handler_url(self, 'transcript_file_handler') if self.transcript_file else "",
                 'transcript_file_name': os.path.basename(self.transcript_file) if self.transcript_file else "",
-                'allow_audio_download': self.allow_audio_download,
                 'start_time': convert_seconds_to_time(self.start_time),
                 'end_time': convert_seconds_to_time(self.end_time),
             }
@@ -101,7 +99,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         Player view, displayed to the student
         """
         sources = list(filter(None, self.sources.split('\n')) if self.sources else '')
-        audio_download_url = sources[0] if sources else None
 
         # Add the MIME type if we think we know it.
         annotated_sources = []
@@ -114,8 +111,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             'templates/html/audio.html', {
                 'audio_id': self.audio_id,
                 'sources': annotated_sources,
-                'allow_audio_download': self.allow_audio_download,
-                'audio_download_url': audio_download_url,
                 'description': self.description,
                 'resolved_transcript_url': resolved_transcript_url,
                 'start_time': self.start_time,
@@ -142,7 +137,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         data = request.POST
         self.description = data.get('description', "")
         self.sources = data.get('sources')
-        self.allow_audio_download = data.get('allow_audio_download') == 'true'
         self.start_time = float(self.convert_time_to_seconds(data.get('start_time', '00:00')))
         self.end_time = float(self.convert_time_to_seconds(data.get('end_time', '00:00')))
         self.embed_url = data.get('embed_url', '') if not data.get('sources', '') else ''

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
+from functools import partial
 import logging
 import pkg_resources
 import os
+from uuid import uuid4
 from django.conf import settings
+from django.core.files import File
 from webob.response import Response
 
 from xblock.core import XBlock
 from xblock.fragment import Fragment
 
 from .fields import AudioFields
-from .utils import get_path_mimetype
+from .utils import get_path_mimetype, get_storage_backend
 
 try:
     from xblock.utils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
@@ -60,6 +63,15 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         except ValueError:
             return 0.0
 
+    def get_resolved_transcript_url(self):
+        """
+        Return the transcript url to be used (if present) for the xblock.
+        """
+        if self.transcript_url:
+            return self.transcript_url
+        elif self.transcript_file:
+            return self.runtime.handler_url(self, 'transcript_file_handler')
+
     def studio_view(self, context):
         """
         View for editing the XBlock settings in Studio
@@ -69,7 +81,9 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'description': self.description,
                 'sources': self.sources,
                 'embed_url': self.embed_url,
-                'transcript_url': self.transcript_url,
+                'transcript_url': self.transcript_url or "",
+                'transcript_file_url': self.runtime.handler_url(self, 'transcript_file_handler') if self.transcript_file else "",
+                'transcript_file_name': os.path.basename(self.transcript_file) if self.transcript_file else "",
                 'allow_audio_download': self.allow_audio_download,
                 'start_time': convert_seconds_to_time(self.start_time),
                 'end_time': convert_seconds_to_time(self.end_time),
@@ -81,7 +95,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/audio_edit.js'))
         fragment.initialize_js('AudioBlockStudio')
         return fragment
-
 
     def student_view(self, context):
         """
@@ -96,6 +109,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             type = get_path_mimetype(source)
             annotated_sources.append((source, type))
 
+        resolved_transcript_url = self.get_resolved_transcript_url()
         html = self.loader.render_django_template(
             'templates/html/audio.html', {
                 'audio_id': self.audio_id,
@@ -103,7 +117,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'allow_audio_download': self.allow_audio_download,
                 'audio_download_url': audio_download_url,
                 'description': self.description,
-                'transcript_file': self.transcript_url or self.transcript_file,
+                'resolved_transcript_url': resolved_transcript_url,
                 'start_time': self.start_time,
                 'end_time': self.end_time,
                 'embed_url': self.embed_url
@@ -134,15 +148,39 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         self.embed_url = data.get('embed_url', '') if not data.get('sources', '') else ''
         self.transcript_url = data.get('transcript_url')
 
-        if 'transcript_file' in request.params and hasattr(request.params['transcript_file'], 'file'):
-            transcript_file = request.params['transcript_file']
-            file_name = transcript_file.filename
-            file_path = os.path.join(settings.MEDIA_ROOT, 'transcripts', file_name)
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            with open(file_path, 'wb') as f:
-                f.write(transcript_file.file.read())
-            self.transcript_file = f'/media/transcripts/{file_name}'
-        else:
+        storage = get_storage_backend()
+        will_upload_transcript_file = 'transcript_file' in data and hasattr(data.get('transcript_file'), 'file')
+
+        if data.get("delete_transcript_file", "") == "on" or will_upload_transcript_file:
+            if self.transcript_file and storage.exists(self.transcript_file):
+                storage.delete(self.transcript_file)
             self.transcript_file = None
 
+        if will_upload_transcript_file:
+            transcript_file = data['transcript_file']
+
+            # generate a safe path for the transcript file
+            loc = self.location
+            file_path = f"{loc.org}/{loc.course}/{loc.block_type}/{loc.block_id}/{uuid4()}.vtt"
+            storage.save(file_path, File(transcript_file.file))
+            self.transcript_file = file_path
+
         return Response(json_body={'result': 'success'})
+
+    @XBlock.handler
+    def transcript_file_handler(self, request, suffix=''):
+        BLOCK_SIZE = 2 ** 10 * 8  # 8kb
+        storage = get_storage_backend()
+        path = self.transcript_file
+
+        if path:
+            try:
+                return Response(
+                    app_iter=iter(partial(storage.open(path).read, BLOCK_SIZE), b""),
+                    content_type='text/vtt',
+                    content_disposition=f"attachment; filename*=UTF-8''{os.path.basename(path)}",
+                )
+            except OSError:
+                pass
+
+        return Response("file not found", status_code=404)

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -27,13 +27,6 @@ class AudioFields(object):
         multiline_editor=True,
     )
 
-    allow_audio_download = Boolean(
-        help=_(u"Allow students to download the source audio file.  If enabled, the first source URL specified will be used."),
-        display_name=_(u"Audio Download Allowed"),
-        scope=Scope.settings,
-        default=True,
-    )
-
     description = String(
         display_name="Description",
         default="",

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -90,4 +90,4 @@ class AudioFields(object):
                         if path is None:
                             validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"Invalid URL '") + source + _(u"' entered.")))
         if data.transcript_file and data.transcript_url:
-            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You must specify at most one transcript source!")))
+            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You may only specify a single transcript source (an uploaded file OR a url). Please remove one to continue.")))

--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -1,6 +1,7 @@
 .audio-xblock {
   display: block;
   margin-bottom: 4rem;
+  margin-top: 4rem;
 }
 
 .mejs-container {
@@ -60,6 +61,12 @@
 
 .mejs-time-total, .mejs-time-loaded, .mejs-time-current, .mejs-time-handle, .mejs-time-float {
   max-width: 100% !important;
+}
+
+.mejs-captions-selector label {
+    text-shadow: none;
+    margin-bottom: 0;
+    color: white;
 }
 
 .tab-container {

--- a/audio/public/js/audio.js
+++ b/audio/public/js/audio.js
@@ -7,7 +7,23 @@ function AudioBlock(runtime, element) {
 
     // these default to 0.0 if unset
     const startTime = parseFloat(audioElement.dataset.startTime);
-    const endTime = parseFloat(audioElement.dataset.endTime);
+
+    // calculate end time on the fly,
+    // because it should be within the actual audio duration,
+    // and the audio duration may not be available when the script initially runs.
+    function getEndTime() {
+      const endTime = parseFloat(audioElement.dataset.endTime);
+      if (endTime == 0.0) {
+        return 0.0;
+      }
+
+      const duration = audioElement.duration;
+      if (!Number.isNaN(duration)) {
+        return Math.min(duration, endTime);
+      }
+
+      return endTime;
+    }
 
     $(audioElement).mediaelementplayer({
         features: ['playpause', 'progress', 'volume', 'tracks', 'fullscreen'],
@@ -16,6 +32,7 @@ function AudioBlock(runtime, element) {
             mediaElement.setCurrentTime(startTime);
 
             mediaElement.addEventListener('timeupdate', function() {
+                const endTime = getEndTime();
                 if (endTime > 0 && mediaElement.currentTime >= endTime) {
                     mediaElement.pause();
                     mediaElement.setCurrentTime(startTime);
@@ -24,24 +41,28 @@ function AudioBlock(runtime, element) {
             });
 
             mediaElement.addEventListener('play', function() {
+                const endTime = getEndTime();
                 if (mediaElement.currentTime < startTime || (endTime > 0 && mediaElement.currentTime >= endTime)) {
                     mediaElement.setCurrentTime(startTime);
                 }
             });
 
             mediaElement.addEventListener('seeking', function() {
+                const endTime = getEndTime();
                 if (mediaElement.currentTime < startTime || (endTime > 0 && mediaElement.currentTime >= endTime)) {
                     mediaElement.setCurrentTime(startTime);
                 }
             });
 
             mediaElement.addEventListener('loadedmetadata', function() {
+                const endTime = getEndTime();
                 if (endTime > 0) {
                     mediaElement.setCurrentTime(startTime);
                 }
             });
 
             mediaElement.addEventListener('timeupdate', function() {
+                const endTime = getEndTime();
                 if (endTime > 0) {
                     const playedPercent = (mediaElement.currentTime - startTime) / (endTime - startTime);
                     const progressBar = $(element).find('.mejs-time-current');

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -44,7 +44,6 @@ function AudioBlockStudio(runtime, element) {
             $('#sources').val('');
             $('#transcript-file').val('');
             $('#transcript-url').val('');
-            $('#allow-audio-download').val('true');
             $('#start-time-checkbox').prop('checked', false);
         }
     }

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -14,8 +14,8 @@
           <source src="{{ source }}" type="{{ type }}" />
         {% endif %}
       {% endfor %}
-      {% if transcript_file %}
-        <track kind="subtitles" src="{{ transcript_file }}" srclang="en" label="English" default/>
+      {% if resolved_transcript_url %}
+        <track kind="subtitles" src="{{ resolved_transcript_url }}" srclang="en" label="English" default/>
       {% endif %}
     </audio>
     {% if allow_audio_download and audio_download_url %}

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -19,7 +19,7 @@
       {% endif %}
     </audio>
     {% if allow_audio_download and audio_download_url %}
-      <div class="audio-xblock-download"><a href="{{ audio_download_url }}">Download audio</a></div>
+      <div class="audio-xblock-download"><a href="{{ audio_download_url }}" target="_blank" rel="noopener" download>Download audio</a></div>
     {% endif %}
   </div>
 {% endif %}

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -18,8 +18,5 @@
         <track kind="subtitles" src="{{ resolved_transcript_url }}" srclang="en" label="English" default/>
       {% endif %}
     </audio>
-    {% if allow_audio_download and audio_download_url %}
-      <div class="audio-xblock-download"><a href="{{ audio_download_url }}" target="_blank" rel="noopener" download>Download audio</a></div>
-    {% endif %}
   </div>
 {% endif %}

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -48,14 +48,6 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <input type="text" id="transcript-url" name="transcript_url" value="{{ transcript_url }}" />
                 <p class="help">Only WebVTT format is supported.</p>
             </div>
-            <div class="field">
-                <label for="allow-audio-download">Allow audio download</label>
-                <select id="allow-audio-download" name="allow_audio_download">
-                    <option value="true" {% if allow_audio_download %}selected{% endif %}>Yes</option>
-                    <option value="false" {% if not allow_audio_download %}selected{% endif %}>No</option>
-                </select>
-                <p class="help">You can allow students to download the source file of this audio.</p>
-            </div>
             <div class="checkbox-container">
                 <input type="checkbox" id="start-time-checkbox" name="start_time_checkbox" {% if start_time != '00:00' or end_time != '00:00' %}checked{% endif %}/>
                 <label for="start-time-checkbox">Set start and end time</label>

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -30,7 +30,16 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <p class="help">Enter the URL for the audio here. To improve compatibility with a range of browsers, you may wish to provide multiple versions of the same audio (for example, an MP3 version and an Ogg Vorbis version). If so, place each URL on a new line.</p>
             </div>
             <div class="field">
-                <label for="transcript-file">Audio transcript</label>
+                <p class="help">If you wish to add a transcript below, please either upload a file or provide a URL (but not both).</p>
+                <label for="transcript-file">Audio transcript file</label>
+                {% if transcript_file_url %}
+                <div>
+                    <small>Currently:</small>
+                    <a href="{{ transcript_file_url }}">{{ transcript_file_name }}</a>
+                    <input type="checkbox" id="delete-transcript-file" name="delete_transcript_file" />
+                    <label for="delete-transcript-file">Delete</label>
+                </div>
+                {% endif %}
                 <input type="file" id="transcript-file" name="transcript_file" />
                 <p class="help">Only WebVTT format is supported.</p>
             </div>

--- a/audio/utils.py
+++ b/audio/utils.py
@@ -1,3 +1,8 @@
+from django.conf import settings
+from django.core.files.storage import default_storage as django_default_storage
+from django.core.files.storage import storages
+
+
 def get_path_mimetype(path):
     ipath = path.lower()
     if ipath.endswith(".mp3"):
@@ -12,3 +17,10 @@ def get_path_mimetype(path):
         return "audio/mp4"
 
     return None
+
+
+def get_storage_backend():
+    storages_config = getattr(settings, "STORAGES", {})
+    if "xblock_audio_storage" in storages_config:
+        return storages["xblock_audio_storage"]
+    return django_default_storage


### PR DESCRIPTION
## Description

In most browsers, clicking the "download audio" link would open the audio in an embedded player,
rather than downloading the audio file.
So here we remove the link altogether.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9935

## Testing instructions

- create and edit an audio component
- verify there is no field to allow or disallow audio download
- save and view the audio component in the cms and then view in the lms
- verify there is no button or link to download the audio
- verify there are no display or layout issues (eg. that could be caused by the removal of the button)

## Deadline

None

## Other information

My only concern with this route is that it makes it very difficult for students to download the audio (even if instructors intend for students to download it). If we were using the built-in browser audio player, users can right click and select "Save audio as...". But we're using the mediaelement.js player which does not provide that option.

An alternate route may be to change the text or add help text - eg. "if clicking this link does not download the audio, try right clicking (or long press on mobile) and selecting 'save as'".

If we do go this way, I'm not sure if we want this removed altogether, or put behind some kind of setting/option/feature flag.