### PR TITLE
docs: improve docs for download audio link

### DIFF
--- a/audio/fields.py
+++ b/audio/fields.py
@@ -28,7 +28,7 @@ class AudioFields(object):
     )
 
     allow_audio_download = Boolean(
-        help=_(u"Allow students to download the source audio file.  If enabled, the first source URL specified will be used."),
+        help=_(u"Provide a link to download the source audio file.  If enabled, the first source URL specified will be used."),
         display_name=_(u"Audio Download Allowed"),
         scope=Scope.settings,
         default=True,

--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -156,3 +156,7 @@
   flex-direction: column;
   margin-top: 10px;
 }
+
+.audio-xblock-download {
+    margin-top: 1rem;
+}

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -19,7 +19,10 @@
       {% endif %}
     </audio>
     {% if allow_audio_download and audio_download_url %}
-      <div class="audio-xblock-download"><a href="{{ audio_download_url }}" target="_blank" rel="noopener" download>Download audio</a></div>
+      <p class="audio-xblock-download">
+          <a href="{{ audio_download_url }}" target="_blank" rel="noopener" download>Download audio</a>
+          (Right click or long press on the download link and select the "Save as" option to download. Clicking on the link might open it for playback in a tab.)
+      </p>
     {% endif %}
   </div>
 {% endif %}

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -49,12 +49,12 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <p class="help">Only WebVTT format is supported.</p>
             </div>
             <div class="field">
-                <label for="allow-audio-download">Allow audio download</label>
+                <label for="allow-audio-download">Show audio download link</label>
                 <select id="allow-audio-download" name="allow_audio_download">
                     <option value="true" {% if allow_audio_download %}selected{% endif %}>Yes</option>
                     <option value="false" {% if not allow_audio_download %}selected{% endif %}>No</option>
                 </select>
-                <p class="help">You can allow students to download the source file of this audio.</p>
+                <p class="help">You can provide a link for students to easily download the source file of this audio. If enabled, the first source URL will be used. Please note that even if this is disabled, students can still technically download the audio by inspecting the audio player in their browser.</p>
             </div>
             <div class="checkbox-container">
                 <input type="checkbox" id="start-time-checkbox" name="start_time_checkbox" {% if start_time != '00:00' or end_time != '00:00' %}checked{% endif %}/>


### PR DESCRIPTION
## Description

This fixes two issues:

1. The "download audio" link didn't necessarily "download" the audio - browsers open will open an embedded player in the browser. This fixes it by adding help text for how to download if that happens.
2. The "allow download" option is misleading, as it suggests that you can prevent students from downloading the audio by disabling the option. This fixes it by rewording the option and adding a warning to the effect that students can still download the audio even with it disabled (albeit with some difficulty).

<details>
<summary>UI screenshots</summary>

Studio edit view:
<img width="1225" height="218" alt="1755480481" src="https://github.com/user-attachments/assets/fdfb06fc-f38f-4825-820a-446da6389643" />

Student view:
<img width="1677" height="276" alt="1755480506" src="https://github.com/user-attachments/assets/855168a4-1e3a-4f7c-a90b-618f9876833c" />



</details>

## Supporting information

Private ref: https://tasks.opencraft.com/browse/BB-9935

## Testing instructions

- create and edit an audio block, setting the "Show audio download link" option to "Yes"
- verify the new option name and help text makes sense
- save and view the audio block
- verify the download audio link help text makes sense

## Deadline

None (although merge by 2025-08-19 to meet the end of sprint deadline would be handy)