### PR TITLE
chore: remove delete transcript checkbox

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -151,15 +151,14 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         storage = get_storage_backend()
         will_upload_transcript_file = 'transcript_file' in data and hasattr(data.get('transcript_file'), 'file')
 
-        if data.get("delete_transcript_file", "") == "on" or will_upload_transcript_file:
+        if will_upload_transcript_file:
+            # clean up any existing file first
             if self.transcript_file and storage.exists(self.transcript_file):
                 storage.delete(self.transcript_file)
             self.transcript_file = None
 
-        if will_upload_transcript_file:
+            # generate a safe path for the transcript file and save it
             transcript_file = data['transcript_file']
-
-            # generate a safe path for the transcript file
             name = get_valid_filename(transcript_file.filename)
             safe_usage_key = get_valid_filename(self.usage_key)
             file_path = f"{safe_usage_key}/transcripts/{name}"

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -34,10 +34,8 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <label for="transcript-file">Audio transcript file</label>
                 {% if transcript_file_url %}
                 <div>
-                    <small>Currently:</small>
+                    <small>Currently saved:</small>
                     <a href="{{ transcript_file_url }}">{{ transcript_file_name }}</a>
-                    <input type="checkbox" id="delete-transcript-file" name="delete_transcript_file" />
-                    <label for="delete-transcript-file">Delete</label>
                 </div>
                 {% endif %}
                 <input type="file" id="transcript-file" name="transcript_file" />


### PR DESCRIPTION
## Description

The UI/UX of this still needs discussion.
In the meantime, remove the checkbox.

## Supporting information

Follow up to https://github.com/open-craft/xblock-audio/pull/6#discussion_r2268785655

Private-ref: https://tasks.opencraft.com/browse/BB-9935

## Test instructions

- create and edit an audio block
- upload a transcript and save
- edit the block again
- verify that there is no option to delete the saved transcript
- upload a new transcript and save
- edit the block again
- verify the new transcript is there instead
- check the backend storage on disk and verify that only the new transcript is saved to disk (the previous one should have been cleaned up)