### PR TITLE
fix: improve delete transcript UI

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -157,8 +157,9 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             self.transcript_file = None
 
         if will_upload_transcript_file:
-            # generate a safe path for the transcript file and save it
             transcript_file = data['transcript_file']
+
+            # generate a safe path for the transcript file
             name = get_valid_filename(transcript_file.filename)
             safe_usage_key = get_valid_filename(self.usage_key)
             file_path = f"{safe_usage_key}/transcripts/{name}"

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -151,12 +151,12 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         storage = get_storage_backend()
         will_upload_transcript_file = 'transcript_file' in data and hasattr(data.get('transcript_file'), 'file')
 
-        if will_upload_transcript_file:
-            # clean up any existing file first
+        if data.get("delete_transcript_file", "") == "on" or will_upload_transcript_file:
             if self.transcript_file and storage.exists(self.transcript_file):
                 storage.delete(self.transcript_file)
             self.transcript_file = None
 
+        if will_upload_transcript_file:
             # generate a safe path for the transcript file and save it
             transcript_file = data['transcript_file']
             name = get_valid_filename(transcript_file.filename)
@@ -184,15 +184,3 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 pass
 
         return Response("file not found", status_code=404)
-
-    @XBlock.handler
-    def remove_transcript(self, request, suffix=''):
-        """
-        Remove (delete) the transcript file from the block if any.
-        """
-        storage = get_storage_backend()
-        if self.transcript_file and storage.exists(self.transcript_file):
-            storage.delete(self.transcript_file)
-        self.transcript_file = None
-
-        return Response(json_body={'result': 'success'})

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -151,15 +151,14 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         storage = get_storage_backend()
         will_upload_transcript_file = 'transcript_file' in data and hasattr(data.get('transcript_file'), 'file')
 
-        if data.get("delete_transcript_file", "") == "on" or will_upload_transcript_file:
+        if will_upload_transcript_file:
+            # clean up any existing file first
             if self.transcript_file and storage.exists(self.transcript_file):
                 storage.delete(self.transcript_file)
             self.transcript_file = None
 
-        if will_upload_transcript_file:
+            # generate a safe path for the transcript file and save it
             transcript_file = data['transcript_file']
-
-            # generate a safe path for the transcript file
             name = get_valid_filename(transcript_file.filename)
             safe_usage_key = get_valid_filename(self.usage_key)
             file_path = f"{safe_usage_key}/transcripts/{name}"
@@ -185,3 +184,15 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 pass
 
         return Response("file not found", status_code=404)
+
+    @XBlock.handler
+    def remove_transcript(self, request, suffix=''):
+        """
+        Remove (delete) the transcript file from the block if any.
+        """
+        storage = get_storage_backend()
+        if self.transcript_file and storage.exists(self.transcript_file):
+            storage.delete(self.transcript_file)
+        self.transcript_file = None
+
+        return Response(json_body={'result': 'success'})

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -27,6 +27,15 @@ function AudioBlockStudio(runtime, element) {
         }
     });
 
+    $(element).find('.remove-transcript-button').click(function(event) {
+        event.preventDefault();
+        $.ajax({
+            url: runtime.handlerUrl(element, 'remove_transcript'),
+            type: 'POST',
+        });
+        $('#current-transcript').remove();
+    });
+
     window.audioSwitchType = function(tab) {
         if (tab === 'audio-tab') {
             $('#audio-tab').show();

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -29,11 +29,9 @@ function AudioBlockStudio(runtime, element) {
 
     $(element).find('.remove-transcript-button').click(function(event) {
         event.preventDefault();
-        $.ajax({
-            url: runtime.handlerUrl(element, 'remove_transcript'),
-            type: 'POST',
-        });
+        $('#delete-transcript-file').prop("checked", true);
         $('#current-transcript').remove();
+
     });
 
     window.audioSwitchType = function(tab) {

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -31,7 +31,6 @@ function AudioBlockStudio(runtime, element) {
         event.preventDefault();
         $('#delete-transcript-file').prop("checked", true);
         $('#current-transcript').remove();
-
     });
 
     window.audioSwitchType = function(tab) {

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -38,6 +38,7 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                     <a href="{{ transcript_file_url }}">{{ transcript_file_name }}</a>
                     (<a href="#" class="button remove-transcript-button">Remove</a>)
                 </div>
+                <input type="checkbox" id="delete-transcript-file" name="delete_transcript_file" style="display: none;" />
                 {% endif %}
                 <input type="file" id="transcript-file" name="transcript_file" />
                 <p class="help">Only WebVTT format is supported.</p>

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -33,11 +33,10 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <p class="help">If you wish to add a transcript below, please either upload a file or provide a URL (but not both).</p>
                 <label for="transcript-file">Audio transcript file</label>
                 {% if transcript_file_url %}
-                <div>
-                    <small>Currently:</small>
+                <div id="current-transcript">
+                    Currently saved:
                     <a href="{{ transcript_file_url }}">{{ transcript_file_name }}</a>
-                    <input type="checkbox" id="delete-transcript-file" name="delete_transcript_file" />
-                    <label for="delete-transcript-file">Delete</label>
+                    (<a href="#" class="button remove-transcript-button">Remove</a>)
                 </div>
                 {% endif %}
                 <input type="file" id="transcript-file" name="transcript_file" />


### PR DESCRIPTION
## Description

Change the process to delete a transcript file.
Previously it was a checkbox to delete on save.
Now it's "remove" button that deletes the file.
Note that the file is still only deleted on saving the form.

Screenshot of the new UI:


<img width="2352" height="1001" alt="1755848033" src="https://github.com/user-attachments/assets/ffb3e396-55aa-4aa1-8e3f-79554efd0cc6" />



## Supporting information

Background discussion: https://github.com/open-craft/xblock-audio/pull/6#discussion_r2268785655

Private-ref: https://tasks.opencraft.com/browse/BB-9935

## Testing instructions

- create an audio block in studio/authoring
- add a transcript through the file upload field and save the audio block
- open the audio block for editing again
- verify the previously uploaded transcript file is visible and that it has a button to remove the transcript next to it
- click the "remove" transcript button
- verify the transcript is removed from the UI
- click "cancel" on the form and click to edit the audio block again
- verify the transcript is still there (the removal should only complete once the form is saved)
- click the "remove" transcript button again
- click "save" on the form
- click to edit the audio block again
- verify the transcript file is gone
- verify the transcript file is deleted from disk (if it's a dev tutor deployment, view uploaded files with `tutor dev exec lms -- ls -R /openedx/media/`
- upload a new transcript and save the form
- edit again, and upload yet another transcript (without removing the existing one first)
- save the form
- verify the new transcript is saved
- verify the old transcript has been deleted from disk

## Deadline

None