### PR TITLE
fix: tidy transcripts display

### DIFF
--- a/audio/public/css/audio.css
+++ b/audio/public/css/audio.css
@@ -7,14 +7,22 @@
 .mejs-container {
   width: 100% !important;
   max-width: 100% !important;
+  margin-bottom: 90px;
 }
 
 .mejs-container .mejs-controls {
   position: relative !important;
 }
 
-.mejs-captions-layer .mejs-layer {
+.mejs-captions-layer {
   width: 100% !important;
+}
+
+.mejs-captions-layer .mejs-captions-position {
+  position: unset;
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .mejs-captions-layer .mejs-captions-text {
@@ -22,25 +30,18 @@
   word-wrap: break-word;
   max-width: 40ch;
   background-color: rgba(255, 255, 255, 0.8);
-  padding: 10px;
+  padding: 0;
+  margin: 10px;
   font-size: 18px;
   line-height: 1.2;
   text-align: center;
   color: #000;
-  position: absolute;
-  transform: translateX(-50%);
-  top: 35px;
-  width: 100%;
-  left: 32rem;
-}
-
-.mejs-captions-position {
-  bottom: 50px;
-  left: 50% !important;
-  transform: translateX(-50%);
-  width: 100%;
-  display: flex;
-  justify-content: center;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mejs-controls {

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -5,6 +5,12 @@
     <iframe src="{{ embed_url }}" width="100%" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
 {% else %}
   <div id="{{ audio_id }}" class="audio-xblock">
+    {% if allow_audio_download and audio_download_url %}
+      <p class="audio-xblock-download">
+          <a href="{{ audio_download_url }}" target="_blank" rel="noopener" download>Download audio</a>
+          (Right-click or long-press to save; clicking may play instead)
+      </p>
+    {% endif %}
     <audio preload="metadata" controls="controls" data-start-time="{{ start_time }}" data-end-time="{{ end_time }}">
       Your browser does not support native <code>audio</code> capabilities!
       {% for source, type in sources %}
@@ -18,11 +24,5 @@
         <track kind="subtitles" src="{{ resolved_transcript_url }}" srclang="en" label="English" default/>
       {% endif %}
     </audio>
-    {% if allow_audio_download and audio_download_url %}
-      <p class="audio-xblock-download">
-          <a href="{{ audio_download_url }}" target="_blank" rel="noopener" download>Download audio</a>
-          (Right click or long press on the download link and select the "Save as" option to download. Clicking on the link might open it for playback in a tab.)
-      </p>
-    {% endif %}
   </div>
 {% endif %}


### PR DESCRIPTION
## Description

- centre the transcript text
- move the download link so the transcript is not overlaid on the text, and make the download help text more concise
- allow more lines of transcript to display
  (up to 4 lines; longer text will be hidden with ellipsis)

<details>
<summary>screenshots</summary>

<img width="1392" height="495" alt="1757315637" src="https://github.com/user-attachments/assets/203759d2-fe11-462e-809e-553a38fc88e4" />

<img width="1402" height="510" alt="1757315700" src="https://github.com/user-attachments/assets/758d5086-f0c4-46d8-a75d-252013257bc3" />
</details>

## Supporting information


Private-ref: https://tasks.opencraft.com/browse/BB-10018

## Testing instructions

- create an audio component, and add a transcript with both short and very long lines
- verify the download link and help text is clear and usable
- verify the transcript text is visible, and centred under the audio player
- verify that very long lines are gracefully handled (cut off at 4 lines, overflow shown with ellipsis)
