### PR TITLE
feat: add downloadable transcript file field

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -84,6 +84,8 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'transcript_url': self.transcript_url or "",
                 'transcript_file_url': self.runtime.handler_url(self, 'transcript_file_handler') if self.transcript_file else "",
                 'transcript_file_name': os.path.basename(self.transcript_file) if self.transcript_file else "",
+                'alt_transcript_file_url': self.runtime.handler_url(self, 'alt_transcript_file_handler') if self.alt_transcript_file else "",
+                'alt_transcript_file_name': os.path.basename(self.alt_transcript_file) if self.alt_transcript_file else "",
                 'allow_audio_download': self.allow_audio_download,
                 'start_time': convert_seconds_to_time(self.start_time),
                 'end_time': convert_seconds_to_time(self.end_time),
@@ -118,6 +120,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'audio_download_url': audio_download_url,
                 'description': self.description,
                 'resolved_transcript_url': resolved_transcript_url,
+                'alt_transcript_url': self.runtime.handler_url(self, 'alt_transcript_file_handler') if self.alt_transcript_file else "",
                 'start_time': self.start_time,
                 'end_time': self.end_time,
                 'embed_url': self.embed_url
@@ -166,6 +169,23 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             storage.save(file_path, File(transcript_file.file))
             self.transcript_file = file_path
 
+        will_upload_alt_transcript_file = 'alt_transcript_file' in data and hasattr(data.get('alt_transcript_file'), 'file')
+
+        if data.get("delete_alt_transcript_file", "") == "on" or will_upload_alt_transcript_file:
+            if self.alt_transcript_file and storage.exists(self.alt_transcript_file):
+                storage.delete(self.alt_transcript_file)
+            self.alt_transcript_file = None
+
+        if will_upload_alt_transcript_file:
+            alt_transcript_file = data['alt_transcript_file']
+
+            # generate a safe path for the alt_transcript file
+            name = get_valid_filename(alt_transcript_file.filename)
+            safe_usage_key = get_valid_filename(self.usage_key)
+            file_path = f"{safe_usage_key}/alt_transcripts/{name}"
+            storage.save(file_path, File(alt_transcript_file.file))
+            self.alt_transcript_file = file_path
+
         return Response(json_body={'result': 'success'})
 
     @XBlock.handler
@@ -179,6 +199,24 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 return Response(
                     app_iter=iter(partial(storage.open(path).read, BLOCK_SIZE), b""),
                     content_type='text/vtt',
+                    content_disposition=f"attachment; filename*=UTF-8''{os.path.basename(path)}",
+                )
+            except OSError:
+                pass
+
+        return Response("file not found", status_code=404)
+
+    @XBlock.handler
+    def alt_transcript_file_handler(self, request, suffix=''):
+        BLOCK_SIZE = 2 ** 10 * 8  # 8kb
+        storage = get_storage_backend()
+        path = self.alt_transcript_file
+
+        if path:
+            try:
+                return Response(
+                    app_iter=iter(partial(storage.open(path).read, BLOCK_SIZE), b""),
+                    content_type='application/octet-stream',
                     content_disposition=f"attachment; filename*=UTF-8''{os.path.basename(path)}",
                 )
             except OSError:

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -47,6 +47,12 @@ class AudioFields(object):
         scope=Scope.settings
     )
 
+    alt_transcript_file = String(
+        help="Alternate transcript file path",
+        default=None,
+        scope=Scope.settings
+    )
+
     transcript_url = String(
         help="Transcript file URL",
         default=None,

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -43,7 +43,10 @@ function AudioBlockStudio(runtime, element) {
             $('#end-time').val('00:00');
             $('#sources').val('');
             $('#transcript-file').val('');
+            $('#delete-transcript-file').prop('checked', false);
             $('#transcript-url').val('');
+            $('#alt-transcript-file').val('');
+            $('#delete-alt-transcript-file').prop('checked', false);
             $('#allow-audio-download').val('true');
             $('#start-time-checkbox').prop('checked', false);
         }

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -11,6 +11,9 @@
           (Right-click or long-press to save; clicking may play instead)
       </p>
     {% endif %}
+    {% if alt_transcript_url %}
+        <p><a href="{{ alt_transcript_url }}" target="_blank" rel="noopener">Download transcript</a></p>
+    {% endif %}
     <audio preload="metadata" controls="controls" data-start-time="{{ start_time }}" data-end-time="{{ end_time }}">
       Your browser does not support native <code>audio</code> capabilities!
       {% for source, type in sources %}

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -56,6 +56,19 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 </select>
                 <p class="help">You can provide a link for students to easily download the source file of this audio. If enabled, the first source URL will be used. Please note that even if this is disabled, students can still technically download the audio by inspecting the audio player in their browser.</p>
             </div>
+            <div class="field">
+                <label for="alt-transcript-file">Alternate downloadable transcript file</label>
+                {% if alt_transcript_file_url %}
+                <div>
+                    <small>Currently:</small>
+                    <a href="{{ alt_transcript_file_url }}">{{ alt_transcript_file_name }}</a>
+                    <input type="checkbox" id="delete-alt-transcript-file" name="delete_alt_transcript_file" />
+                    <label for="delete-alt-transcript-file">Delete</label>
+                </div>
+                {% endif %}
+                <input type="file" id="alt-transcript-file" name="alt_transcript_file" />
+                <p class="help">Use this to upload a transcript in a format other than WebVTT. It won't appear as captions - only a download link will be provided.</p>
+            </div>
             <div class="checkbox-container">
                 <input type="checkbox" id="start-time-checkbox" name="start_time_checkbox" {% if start_time != '00:00' or end_time != '00:00' %}checked{% endif %}/>
                 <label for="start-time-checkbox">Set start and end time</label>


### PR DESCRIPTION
## Description

This is to support uploading a pdf transcript file that can be downloaded by the student.
This is in addition to the existing transcript fields.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-10236

## Testing instructions

- Install this xblock and branch on a devstack.
- Navigate to the advanced settings for a course in studio/authoring, and add "audio" to the advanced module list.
- Create a unit and add an instance of this audio xblock.
- Experiment with adding and deleting files of various types to the new "Alternate downloadable transcript file" field.
- Verify that when an alternate transcript file is available, there is a "download transcript" link on the student view of the component.
- Verify that clicking the link opens the file in a new tab and/or downloads the file (we don't have much control over this, but at least it must never navigate away from the current page).
- Verify that deleting the transcript file deletes it from disk too. (in a Tutor devstack, this should be /openedx/media/ in the cms and lms shell (volume backed))

## Deadline

None