### PR TITLE
feat!: switch uploaded file to url for alt transcript

### DIFF
--- a/audio/audio.py
+++ b/audio/audio.py
@@ -84,8 +84,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'transcript_url': self.transcript_url or "",
                 'transcript_file_url': self.runtime.handler_url(self, 'transcript_file_handler') if self.transcript_file else "",
                 'transcript_file_name': os.path.basename(self.transcript_file) if self.transcript_file else "",
-                'alt_transcript_file_url': self.runtime.handler_url(self, 'alt_transcript_file_handler') if self.alt_transcript_file else "",
-                'alt_transcript_file_name': os.path.basename(self.alt_transcript_file) if self.alt_transcript_file else "",
+                'alt_transcript_url': self.alt_transcript_url,
                 'allow_audio_download': self.allow_audio_download,
                 'start_time': convert_seconds_to_time(self.start_time),
                 'end_time': convert_seconds_to_time(self.end_time),
@@ -120,7 +119,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'audio_download_url': audio_download_url,
                 'description': self.description,
                 'resolved_transcript_url': resolved_transcript_url,
-                'alt_transcript_url': self.runtime.handler_url(self, 'alt_transcript_file_handler') if self.alt_transcript_file else "",
+                'alt_transcript_url': self.alt_transcript_url,
                 'start_time': self.start_time,
                 'end_time': self.end_time,
                 'embed_url': self.embed_url
@@ -150,6 +149,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         self.end_time = float(self.convert_time_to_seconds(data.get('end_time', '00:00')))
         self.embed_url = data.get('embed_url', '') if not data.get('sources', '') else ''
         self.transcript_url = data.get('transcript_url')
+        self.alt_transcript_url = data.get('alt_transcript_url')
 
         storage = get_storage_backend()
         will_upload_transcript_file = 'transcript_file' in data and hasattr(data.get('transcript_file'), 'file')
@@ -169,23 +169,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             storage.save(file_path, File(transcript_file.file))
             self.transcript_file = file_path
 
-        will_upload_alt_transcript_file = 'alt_transcript_file' in data and hasattr(data.get('alt_transcript_file'), 'file')
-
-        if data.get("delete_alt_transcript_file", "") == "on" or will_upload_alt_transcript_file:
-            if self.alt_transcript_file and storage.exists(self.alt_transcript_file):
-                storage.delete(self.alt_transcript_file)
-            self.alt_transcript_file = None
-
-        if will_upload_alt_transcript_file:
-            alt_transcript_file = data['alt_transcript_file']
-
-            # generate a safe path for the alt_transcript file
-            name = get_valid_filename(alt_transcript_file.filename)
-            safe_usage_key = get_valid_filename(self.usage_key)
-            file_path = f"{safe_usage_key}/alt_transcripts/{name}"
-            storage.save(file_path, File(alt_transcript_file.file))
-            self.alt_transcript_file = file_path
-
         return Response(json_body={'result': 'success'})
 
     @XBlock.handler
@@ -199,24 +182,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 return Response(
                     app_iter=iter(partial(storage.open(path).read, BLOCK_SIZE), b""),
                     content_type='text/vtt',
-                    content_disposition=f"attachment; filename*=UTF-8''{os.path.basename(path)}",
-                )
-            except OSError:
-                pass
-
-        return Response("file not found", status_code=404)
-
-    @XBlock.handler
-    def alt_transcript_file_handler(self, request, suffix=''):
-        BLOCK_SIZE = 2 ** 10 * 8  # 8kb
-        storage = get_storage_backend()
-        path = self.alt_transcript_file
-
-        if path:
-            try:
-                return Response(
-                    app_iter=iter(partial(storage.open(path).read, BLOCK_SIZE), b""),
-                    content_type='application/octet-stream',
                     content_disposition=f"attachment; filename*=UTF-8''{os.path.basename(path)}",
                 )
             except OSError:

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -47,9 +47,9 @@ class AudioFields(object):
         scope=Scope.settings
     )
 
-    alt_transcript_file = String(
-        help="Alternate transcript file path",
-        default=None,
+    alt_transcript_url = String(
+        help="Alternate transcript file url. A link to this url will be displayed, labelled 'Download transcript'.",
+        default="",
         scope=Scope.settings
     )
 

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -45,8 +45,7 @@ function AudioBlockStudio(runtime, element) {
             $('#transcript-file').val('');
             $('#delete-transcript-file').prop('checked', false);
             $('#transcript-url').val('');
-            $('#alt-transcript-file').val('');
-            $('#delete-alt-transcript-file').prop('checked', false);
+            $('#alt-transcript-url').val('');
             $('#allow-audio-download').val('true');
             $('#start-time-checkbox').prop('checked', false);
         }

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -57,17 +57,9 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <p class="help">You can provide a link for students to easily download the source file of this audio. If enabled, the first source URL will be used. Please note that even if this is disabled, students can still technically download the audio by inspecting the audio player in their browser.</p>
             </div>
             <div class="field">
-                <label for="alt-transcript-file">Alternate downloadable transcript file</label>
-                {% if alt_transcript_file_url %}
-                <div>
-                    <small>Currently:</small>
-                    <a href="{{ alt_transcript_file_url }}">{{ alt_transcript_file_name }}</a>
-                    <input type="checkbox" id="delete-alt-transcript-file" name="delete_alt_transcript_file" />
-                    <label for="delete-alt-transcript-file">Delete</label>
-                </div>
-                {% endif %}
-                <input type="file" id="alt-transcript-file" name="alt_transcript_file" />
-                <p class="help">Use this to upload a transcript in a format other than WebVTT. It won't appear as captions - only a download link will be provided.</p>
+                <label for="alt-transcript-url">Alternate downloadable transcript url</label>
+                <input type="text" id="alt-transcript-url" name="alt_transcript_url" value="{{ alt_transcript_url }}" />
+                <p class="help">Use this to link to a transcript in a format other than WebVTT. It won't appear as captions - only a download link will be provided.</p>
             </div>
             <div class="checkbox-container">
                 <input type="checkbox" id="start-time-checkbox" name="start_time_checkbox" {% if start_time != '00:00' or end_time != '00:00' %}checked{% endif %}/>


### PR DESCRIPTION
## Description

As per request, this alternate transcript should be simply a link to a url, rather than an uploaded file.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-10236

## Testing instructions

- deploy this to a devstack
- create a new audio component
- add an audio url and save it
- verify there is no "download transcript" link in the student view
- edit the component again, and add an alternate transcript url, and save it
- verify there is a "download transcript" link in the student view
- verify that clicking the "download transcript" link opens the alternate transcript url in a new tab

## Deadline

None