### PR TITLE
feat!: remove transcript file field

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,3 @@ You can enable the XBlock in Studio through `Advanced Settings`.
 1. From the main page of a specific course, navigate to `Settings -> Advanced Settings` from the top menu.
 2. Check for the `advanced_modules` policy key, and add `"audio"` to the policy value list.
 3. Click the "Save changes" button.
-
-## Configuration
-
-Transcript files will be uploaded to the default Django storage.
-If you wish to customise where the transcript files are uploaded,
-set a custom storage config in the [STORAGES](https://docs.djangoproject.com/en/5.2/ref/settings/#storages) setting,
-with the key `xblock_audio_storage`.

--- a/audio/audio.py
+++ b/audio/audio.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
-from functools import partial
 import logging
 import pkg_resources
-import os
 from django.conf import settings
-from django.utils.text import get_valid_filename
-from django.core.files import File
 from webob.response import Response
 
 from xblock.core import XBlock
 from xblock.fragment import Fragment
 
 from .fields import AudioFields
-from .utils import get_path_mimetype, get_storage_backend
+from .utils import get_path_mimetype
 
 try:
     from xblock.utils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
@@ -45,7 +41,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         'sources',
         'allow_audio_download',
         'description',
-        'transcript_file',
         'transcript_url',
         'embed_url',
     )
@@ -63,15 +58,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         except ValueError:
             return 0.0
 
-    def get_resolved_transcript_url(self):
-        """
-        Return the transcript url to be used (if present) for the xblock.
-        """
-        if self.transcript_url:
-            return self.transcript_url
-        elif self.transcript_file:
-            return self.runtime.handler_url(self, 'transcript_file_handler')
-
     def studio_view(self, context):
         """
         View for editing the XBlock settings in Studio
@@ -82,8 +68,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'sources': self.sources,
                 'embed_url': self.embed_url,
                 'transcript_url': self.transcript_url or "",
-                'transcript_file_url': self.runtime.handler_url(self, 'transcript_file_handler') if self.transcript_file else "",
-                'transcript_file_name': os.path.basename(self.transcript_file) if self.transcript_file else "",
                 'alt_transcript_url': self.alt_transcript_url,
                 'allow_audio_download': self.allow_audio_download,
                 'start_time': convert_seconds_to_time(self.start_time),
@@ -110,7 +94,6 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
             type = get_path_mimetype(source)
             annotated_sources.append((source, type))
 
-        resolved_transcript_url = self.get_resolved_transcript_url()
         html = self.loader.render_django_template(
             'templates/html/audio.html', {
                 'audio_id': self.audio_id,
@@ -118,7 +101,7 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
                 'allow_audio_download': self.allow_audio_download,
                 'audio_download_url': audio_download_url,
                 'description': self.description,
-                'resolved_transcript_url': resolved_transcript_url,
+                'transcript_url': self.transcript_url,
                 'alt_transcript_url': self.alt_transcript_url,
                 'start_time': self.start_time,
                 'end_time': self.end_time,
@@ -151,40 +134,4 @@ class AudioBlock(AudioFields, StudioEditableXBlockMixin, StudioContainerXBlockMi
         self.transcript_url = data.get('transcript_url')
         self.alt_transcript_url = data.get('alt_transcript_url')
 
-        storage = get_storage_backend()
-        will_upload_transcript_file = 'transcript_file' in data and hasattr(data.get('transcript_file'), 'file')
-
-        if data.get("delete_transcript_file", "") == "on" or will_upload_transcript_file:
-            if self.transcript_file and storage.exists(self.transcript_file):
-                storage.delete(self.transcript_file)
-            self.transcript_file = None
-
-        if will_upload_transcript_file:
-            transcript_file = data['transcript_file']
-
-            # generate a safe path for the transcript file
-            name = get_valid_filename(transcript_file.filename)
-            safe_usage_key = get_valid_filename(self.usage_key)
-            file_path = f"{safe_usage_key}/transcripts/{name}"
-            storage.save(file_path, File(transcript_file.file))
-            self.transcript_file = file_path
-
         return Response(json_body={'result': 'success'})
-
-    @XBlock.handler
-    def transcript_file_handler(self, request, suffix=''):
-        BLOCK_SIZE = 2 ** 10 * 8  # 8kb
-        storage = get_storage_backend()
-        path = self.transcript_file
-
-        if path:
-            try:
-                return Response(
-                    app_iter=iter(partial(storage.open(path).read, BLOCK_SIZE), b""),
-                    content_type='text/vtt',
-                    content_disposition=f"attachment; filename*=UTF-8''{os.path.basename(path)}",
-                )
-            except OSError:
-                pass
-
-        return Response("file not found", status_code=404)

--- a/audio/fields.py
+++ b/audio/fields.py
@@ -41,12 +41,6 @@ class AudioFields(object):
         help="Description text to be shown before the player."
     )
 
-    transcript_file = String(
-        help="Transcript file path",
-        default=None,
-        scope=Scope.settings
-    )
-
     alt_transcript_url = String(
         help="Alternate transcript file url. A link to this url will be displayed, labelled 'Download transcript'.",
         default="",
@@ -95,5 +89,3 @@ class AudioFields(object):
                         _scheme, _netloc, path, _params, _qs, _fragment = urlparse(source)
                         if path is None:
                             validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"Invalid URL '") + source + _(u"' entered.")))
-        if data.transcript_file and data.transcript_url:
-            validation.add(ValidationMessage(ValidationMessage.ERROR, _(u"You may only specify a single transcript source (an uploaded file OR a url). Please remove one to continue.")))

--- a/audio/public/js/audio_edit.js
+++ b/audio/public/js/audio_edit.js
@@ -42,8 +42,6 @@ function AudioBlockStudio(runtime, element) {
             $('#start-time').val('00:00');
             $('#end-time').val('00:00');
             $('#sources').val('');
-            $('#transcript-file').val('');
-            $('#delete-transcript-file').prop('checked', false);
             $('#transcript-url').val('');
             $('#alt-transcript-url').val('');
             $('#allow-audio-download').val('true');

--- a/audio/templates/html/audio.html
+++ b/audio/templates/html/audio.html
@@ -23,8 +23,8 @@
           <source src="{{ source }}" type="{{ type }}" />
         {% endif %}
       {% endfor %}
-      {% if resolved_transcript_url %}
-        <track kind="subtitles" src="{{ resolved_transcript_url }}" srclang="en" label="English" default/>
+      {% if transcript_url %}
+        <track kind="subtitles" src="{{ transcript_url }}" srclang="en" label="English" default/>
       {% endif %}
     </audio>
   </div>

--- a/audio/templates/html/audio_edit.html
+++ b/audio/templates/html/audio_edit.html
@@ -30,20 +30,6 @@ https://example.com/bird-calls.ogg">{{ sources }}</textarea>
                 <p class="help">Enter the URL for the audio here. To improve compatibility with a range of browsers, you may wish to provide multiple versions of the same audio (for example, an MP3 version and an Ogg Vorbis version). If so, place each URL on a new line.</p>
             </div>
             <div class="field">
-                <p class="help">If you wish to add a transcript below, please either upload a file or provide a URL (but not both).</p>
-                <label for="transcript-file">Audio transcript file</label>
-                {% if transcript_file_url %}
-                <div>
-                    <small>Currently:</small>
-                    <a href="{{ transcript_file_url }}">{{ transcript_file_name }}</a>
-                    <input type="checkbox" id="delete-transcript-file" name="delete_transcript_file" />
-                    <label for="delete-transcript-file">Delete</label>
-                </div>
-                {% endif %}
-                <input type="file" id="transcript-file" name="transcript_file" />
-                <p class="help">Only WebVTT format is supported.</p>
-            </div>
-            <div class="field">
                 <label for="transcript-url">Audio transcript URL</label>
                 <input type="text" id="transcript-url" name="transcript_url" value="{{ transcript_url }}" />
                 <p class="help">Only WebVTT format is supported.</p>

--- a/audio/utils.py
+++ b/audio/utils.py
@@ -1,8 +1,3 @@
-from django.conf import settings
-from django.core.files.storage import default_storage as django_default_storage
-from django.core.files.storage import storages
-
-
 def get_path_mimetype(path):
     ipath = path.lower()
     if ipath.endswith(".mp3"):
@@ -17,10 +12,3 @@ def get_path_mimetype(path):
         return "audio/mp4"
 
     return None
-
-
-def get_storage_backend():
-    storages_config = getattr(settings, "STORAGES", {})
-    if "xblock_audio_storage" in storages_config:
-        return storages["xblock_audio_storage"]
-    return django_default_storage


### PR DESCRIPTION
## Description

The transcript file field is problematic, as it stores the file in a location that is not included in course exports. This means if a transcript file is uploaded, then the course exported and imported into another Open edX instance, the file is lost.

The field is also not currently in use as far as we're aware, so we can simply remove the field.

This still allows timed transcripts, via the transcript url field.

In future if we need support, we will need to consider a better way to handle file uploads. For example, the core Video XBlock handles handout file uploads by directly uploading them to the course Files assets. This isn't ideal though. There are also other methods being considered for future development, so we may have a better supported method in the future.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-10249

## Testing instructions

- deploy the previous revision of this xblock (wgu-release branch) to an instance
- create a component with this xblock, uploading a transcript file
- update the xblock to this revision
- navigate to the previously created component, and verify the component still works, albeit with the transcript missing. (This is to test that it gracefully upgrades; we don't want it to throw an error.)
- edit the xblock again, and add a transcript via the url field (please let me know if you find a good sample webvtt hosted online)
- check the edit view and student view and verify the text and fields, especially around transcripts, makes sense still after the removal of the file field
- Verify the timed transcript still works as expected when using the transcript url field.